### PR TITLE
[FEAT] Auth 마이그레이션: 로그인/회원가입/계정찾기 (Next.js → Flutter MVVM)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,44 @@
+PODS:
+  - Flutter (1.0.0)
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  flutter_secure_storage_darwin:
+    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		D96ADCDCF2524A017C0BD7FE /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D2795E9A6E96A226411878F /* Pods_RunnerTests.framework */; };
+		DEA4D94B0DFF86FC37F2AE21 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F23757546298CDC3A1D6E20 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,12 +44,18 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1AE24F7DC604A328F5546086 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		2C26D9F5080A206DED7B49DD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		66C65FE2A91E7CE227E6FF9D /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7D2795E9A6E96A226411878F /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8507AAD0E163B39C22D62A7E /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		852EA6B6B1E396AAF9E391E4 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +63,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9F23757546298CDC3A1D6E20 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF9361029C3A92C87B2565C1 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +72,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DEA4D94B0DFF86FC37F2AE21 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C037D4507604245F50784264 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D96ADCDCF2524A017C0BD7FE /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +93,29 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		3AC9766CF4135C705FFCF962 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9F23757546298CDC3A1D6E20 /* Pods_Runner.framework */,
+				7D2795E9A6E96A226411878F /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		515C5BBEC4538AA3E5AC3EE9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2C26D9F5080A206DED7B49DD /* Pods-Runner.debug.xcconfig */,
+				1AE24F7DC604A328F5546086 /* Pods-Runner.release.xcconfig */,
+				66C65FE2A91E7CE227E6FF9D /* Pods-Runner.profile.xcconfig */,
+				852EA6B6B1E396AAF9E391E4 /* Pods-RunnerTests.debug.xcconfig */,
+				8507AAD0E163B39C22D62A7E /* Pods-RunnerTests.release.xcconfig */,
+				FF9361029C3A92C87B2565C1 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +136,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				515C5BBEC4538AA3E5AC3EE9 /* Pods */,
+				3AC9766CF4135C705FFCF962 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				3DACE98D417A6B9744B0A290 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				C037D4507604245F50784264 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				E815C129FA74D96820E1602F /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				E2D1762D25928DDCDC9E88BC /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -238,6 +286,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		3DACE98D417A6B9744B0A290 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +322,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E2D1762D25928DDCDC9E88BC /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E815C129FA74D96820E1602F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -379,6 +488,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 852EA6B6B1E396AAF9E391E4 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -396,6 +506,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8507AAD0E163B39C22D62A7E /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -411,6 +522,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FF9361029C3A92C87B2565C1 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/common/config/app_config.dart
+++ b/lib/common/config/app_config.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class AppConfig {
+  AppConfig._();
+
+  static const String _envFile = 'assets/env/.env';
+
+  static Future<void> load() async {
+    await dotenv.load(fileName: _envFile);
+  }
+
+  static String get apiBaseUrl {
+    final raw = dotenv.env['NEXT_PUBLIC_API_URL']?.trim();
+    if (raw == null || raw.isEmpty) {
+      throw StateError('NEXT_PUBLIC_API_URL is missing in $_envFile');
+    }
+    final normalized = raw.endsWith('/') ? raw.substring(0, raw.length - 1) : raw;
+    return '$normalized/api/v1';
+  }
+}
+
+

--- a/lib/common/dio/api_error_mapper.dart
+++ b/lib/common/dio/api_error_mapper.dart
@@ -1,0 +1,36 @@
+import 'api_exception.dart';
+
+/// Next.js의 `extractServerMessage()` 규칙을 최대한 비슷하게 따라감:
+/// - errors[0].reason
+/// - result.message
+/// - message
+/// - fallback
+String mapErrorToMessage(Object error, {Object? responseData}) {
+  Object? body = responseData;
+  if (error is ApiException && body == null) body = error.details;
+
+  if (body is Map) {
+    final errors = body['errors'];
+    if (errors is List && errors.isNotEmpty) {
+      final first = errors.first;
+      if (first is Map && first['reason'] is String) {
+        final reason = first['reason'] as String;
+        if (reason.isNotEmpty) return reason;
+      }
+    }
+
+    final result = body['result'];
+    if (result is Map && result['message'] is String) {
+      final msg = result['message'] as String;
+      if (msg.isNotEmpty) return msg;
+    }
+
+    final message = body['message'];
+    if (message is String && message.isNotEmpty) return message;
+  }
+
+  if (error is ApiException && error.message.isNotEmpty) return error.message;
+  return '요청 처리 중 오류가 발생했습니다.';
+}
+
+

--- a/lib/common/dio/api_exception.dart
+++ b/lib/common/dio/api_exception.dart
@@ -1,0 +1,12 @@
+class ApiException implements Exception {
+  final String message;
+  final int? statusCode;
+  final Object? details;
+
+  ApiException(this.message, {this.statusCode, this.details});
+
+  @override
+  String toString() => 'ApiException(statusCode=$statusCode, message=$message)';
+}
+
+

--- a/lib/common/dio/dio_client.dart
+++ b/lib/common/dio/dio_client.dart
@@ -1,0 +1,81 @@
+import 'package:dio/dio.dart';
+
+import '../config/app_config.dart';
+import 'api_exception.dart';
+
+class DioClient {
+  final Dio _dio;
+
+  DioClient._(this._dio);
+
+  factory DioClient.create() {
+    final options = BaseOptions(
+      baseUrl: AppConfig.apiBaseUrl,
+      headers: const {'Content-Type': 'application/json'},
+      connectTimeout: const Duration(milliseconds: 20000),
+      sendTimeout: const Duration(milliseconds: 20000),
+      receiveTimeout: const Duration(milliseconds: 20000),
+      responseType: ResponseType.json,
+    );
+
+    final dio = Dio(options);
+    dio.interceptors.add(
+      LogInterceptor(
+        request: true,
+        requestHeader: false,
+        requestBody: true,
+        responseHeader: false,
+        responseBody: true,
+        error: true,
+      ),
+    );
+
+    return DioClient._(dio);
+  }
+
+  Future<T> get<T>(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    try {
+      final res = await _dio.get<T>(
+        path,
+        queryParameters: queryParameters,
+        options: Options(headers: headers),
+      );
+      return res.data as T;
+    } on DioException catch (e) {
+      throw ApiException(
+        e.message ?? '네트워크 오류가 발생했습니다.',
+        statusCode: e.response?.statusCode,
+        details: e.response?.data,
+      );
+    }
+  }
+
+  Future<T> post<T>(
+    String path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    try {
+      final res = await _dio.post<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: Options(headers: headers),
+      );
+      return res.data as T;
+    } on DioException catch (e) {
+      throw ApiException(
+        e.message ?? '네트워크 오류가 발생했습니다.',
+        statusCode: e.response?.statusCode,
+        details: e.response?.data,
+      );
+    }
+  }
+}
+
+

--- a/lib/common/storage/token_storage.dart
+++ b/lib/common/storage/token_storage.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class TokenStorage {
+  static const _accessTokenKey = 'access_token';
+
+  final FlutterSecureStorage _storage;
+
+  TokenStorage({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  Future<void> setAccessToken(String token) => _storage.write(key: _accessTokenKey, value: token);
+
+  Future<String?> getAccessToken() => _storage.read(key: _accessTokenKey);
+
+  Future<void> clear() => _storage.delete(key: _accessTokenKey);
+}
+
+

--- a/lib/features/auth/data/auth_api.dart
+++ b/lib/features/auth/data/auth_api.dart
@@ -1,6 +1,7 @@
 import '../../../common/dio/dio_client.dart';
 import '../../users/models/me_response.dart';
 import '../models/login_models.dart';
+import '../models/account_recovery_models.dart';
 import '../models/signup_models.dart';
 
 class AuthApi {
@@ -74,6 +75,28 @@ class AuthApi {
     await _client.post<Object>(
       '/auth/email/verify',
       data: {'email': email, 'code': code},
+    );
+  }
+
+  Future<FindUserIdResponse> findUserId(FindUserIdRequest request) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/auth/find-id',
+      data: request.toJson(),
+    );
+    return FindUserIdResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<void> resetPasswordRequest(String email) async {
+    await _client.post<Object>(
+      '/auth/password/reset/request',
+      data: {'email': email},
+    );
+  }
+
+  Future<void> resetPasswordConfirm(ResetPasswordConfirmRequest request) async {
+    await _client.post<Object>(
+      '/auth/password/reset/confirm',
+      data: request.toJson(),
     );
   }
 }

--- a/lib/features/auth/data/auth_api.dart
+++ b/lib/features/auth/data/auth_api.dart
@@ -1,0 +1,34 @@
+import '../../../common/dio/dio_client.dart';
+import '../../users/models/me_response.dart';
+import '../models/login_models.dart';
+
+class AuthApi {
+  final DioClient _client;
+
+  AuthApi(this._client);
+
+  Map<String, dynamic> _unwrapData(Map<String, dynamic> root) {
+    // 서버가 { data: {...}, result: {...}, errors: ... } 형태로 감싸서 내려주는 케이스 대응
+    final inner = root['data'];
+    if (inner is Map<String, dynamic>) return inner;
+    return root;
+  }
+
+  Future<LoginResponse> login(LoginRequest request) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/auth/login',
+      data: request.toJson(),
+    );
+    return LoginResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<MeResponse> getMe(String token) async {
+    final root = await _client.get<Map<String, dynamic>>(
+      '/auth/me',
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    return MeResponse.fromJson(_unwrapData(root));
+  }
+}
+
+

--- a/lib/features/auth/models/account_recovery_models.dart
+++ b/lib/features/auth/models/account_recovery_models.dart
@@ -1,0 +1,41 @@
+class FindUserIdRequest {
+  final String name;
+  final String email;
+
+  FindUserIdRequest({required this.name, required this.email});
+
+  Map<String, dynamic> toJson() => {'name': name, 'email': email};
+}
+
+class FindUserIdResponse {
+  final String userId;
+
+  FindUserIdResponse({required this.userId});
+
+  factory FindUserIdResponse.fromJson(Map<String, dynamic> json) {
+    return FindUserIdResponse(userId: (json['userId'] ?? '').toString());
+  }
+}
+
+class ResetPasswordConfirmRequest {
+  final String email;
+  final String token;
+  final String newPassword;
+  final String confirmPassword;
+
+  ResetPasswordConfirmRequest({
+    required this.email,
+    required this.token,
+    required this.newPassword,
+    required this.confirmPassword,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'email': email,
+        'token': token,
+        'newPassword': newPassword,
+        'confirmPassword': confirmPassword,
+      };
+}
+
+

--- a/lib/features/auth/models/login_models.dart
+++ b/lib/features/auth/models/login_models.dart
@@ -1,0 +1,32 @@
+import 'role.dart';
+
+class LoginRequest {
+  final Role role;
+  final String userId;
+  final String password;
+
+  LoginRequest({required this.role, required this.userId, required this.password});
+
+  Map<String, dynamic> toJson() => {
+        'role': role.toApi(),
+        // 웹 payload 키와 동일
+        'user_id': userId,
+        'password': password,
+      };
+}
+
+class LoginResponse {
+  final String accessToken;
+  final String? refreshToken;
+
+  LoginResponse({required this.accessToken, this.refreshToken});
+
+  factory LoginResponse.fromJson(Map<String, dynamic> json) {
+    return LoginResponse(
+      accessToken: (json['accessToken'] ?? '').toString(),
+      refreshToken: json['refreshToken']?.toString(),
+    );
+  }
+}
+
+

--- a/lib/features/auth/models/role.dart
+++ b/lib/features/auth/models/role.dart
@@ -1,0 +1,9 @@
+enum Role { student, admin }
+
+extension RoleApi on Role {
+  String toApi() => this == Role.admin ? 'ADMIN' : 'STUDENT';
+
+  static Role fromApi(String value) => value == 'ADMIN' ? Role.admin : Role.student;
+}
+
+

--- a/lib/features/auth/models/signup_models.dart
+++ b/lib/features/auth/models/signup_models.dart
@@ -1,0 +1,41 @@
+import 'role.dart';
+
+class VerifyIdResponse {
+  final bool valid;
+  final String message;
+
+  VerifyIdResponse({required this.valid, required this.message});
+
+  factory VerifyIdResponse.fromJson(Map<String, dynamic> json) {
+    return VerifyIdResponse(
+      valid: json['valid'] == true,
+      message: (json['message'] ?? '').toString(),
+    );
+  }
+}
+
+class SignUpRequest {
+  final Role role;
+  final String userId;
+  final String name;
+  final String email;
+  final String password;
+
+  SignUpRequest({
+    required this.role,
+    required this.userId,
+    required this.name,
+    required this.email,
+    required this.password,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'role': role.toApi(),
+        'userId': userId,
+        'name': name,
+        'email': email,
+        'password': password,
+      };
+}
+
+

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -4,6 +4,7 @@ import '../../users/models/me_response.dart';
 import '../data/auth_api.dart';
 import '../models/login_models.dart';
 import '../models/role.dart';
+import '../models/signup_models.dart';
 
 class AuthRepository {
   final AuthApi _api;
@@ -30,6 +31,16 @@ class AuthRepository {
     if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
     return _api.getMe(token);
   }
+
+  Future<VerifyIdResponse> verifyId(String userId) => _api.verifyId(userId);
+
+  Future<void> signUp(SignUpRequest request) => _api.signUp(request);
+
+  Future<bool> getSignupEmailStatus(String email) => _api.getSignupEmailStatus(email);
+
+  Future<void> sendEmailVerification(String email) => _api.sendEmailVerification(email);
+
+  Future<void> verifyEmail({required String email, required String code}) => _api.verifyEmail(email: email, code: code);
 }
 
 

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -2,6 +2,7 @@ import '../../../common/dio/api_exception.dart';
 import '../../../common/storage/token_storage.dart';
 import '../../users/models/me_response.dart';
 import '../data/auth_api.dart';
+import '../models/account_recovery_models.dart';
 import '../models/login_models.dart';
 import '../models/role.dart';
 import '../models/signup_models.dart';
@@ -41,6 +42,13 @@ class AuthRepository {
   Future<void> sendEmailVerification(String email) => _api.sendEmailVerification(email);
 
   Future<void> verifyEmail({required String email, required String code}) => _api.verifyEmail(email: email, code: code);
+
+  Future<FindUserIdResponse> findUserId({required String name, required String email}) =>
+      _api.findUserId(FindUserIdRequest(name: name, email: email));
+
+  Future<void> resetPasswordRequest(String email) => _api.resetPasswordRequest(email);
+
+  Future<void> resetPasswordConfirm(ResetPasswordConfirmRequest request) => _api.resetPasswordConfirm(request);
 }
 
 

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -1,0 +1,35 @@
+import '../../../common/dio/api_exception.dart';
+import '../../../common/storage/token_storage.dart';
+import '../../users/models/me_response.dart';
+import '../data/auth_api.dart';
+import '../models/login_models.dart';
+import '../models/role.dart';
+
+class AuthRepository {
+  final AuthApi _api;
+  final TokenStorage _tokenStorage;
+
+  AuthRepository({required AuthApi api, required TokenStorage tokenStorage})
+      : _api = api,
+        _tokenStorage = tokenStorage;
+
+  Future<Role> login({required Role role, required String userId, required String password}) async {
+    final res = await _api.login(LoginRequest(role: role, userId: userId, password: password));
+    if (res.accessToken.isEmpty) throw ApiException('로그인에 실패했습니다.');
+    await _tokenStorage.setAccessToken(res.accessToken);
+    final me = await _api.getMe(res.accessToken);
+    return me.role;
+  }
+
+  Future<String?> getAccessToken() => _tokenStorage.getAccessToken();
+
+  Future<void> logout() => _tokenStorage.clear();
+
+  Future<MeResponse> getMe() async {
+    final token = await _tokenStorage.getAccessToken();
+    if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+    return _api.getMe(token);
+  }
+}
+
+

--- a/lib/features/auth/screens/find_account_screen.dart
+++ b/lib/features/auth/screens/find_account_screen.dart
@@ -1,0 +1,286 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../viewmodels/find_account_view_model.dart';
+
+class FindAccountScreen extends StatefulWidget {
+  static const routeName = '/find-account';
+
+  const FindAccountScreen({super.key});
+
+  @override
+  State<FindAccountScreen> createState() => _FindAccountScreenState();
+}
+
+class _FindAccountScreenState extends State<FindAccountScreen> {
+  bool _inited = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_inited) return;
+    _inited = true;
+    context.read<FindAccountViewModel>().initTabFromArgs(ModalRoute.of(context)?.settings.arguments);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<FindAccountViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 8),
+              _FindAccountTabs(
+                tab: vm.tab,
+                onChanged: (vm.loading || vm.verifying) ? null : vm.setTab,
+              ),
+              const SizedBox(height: 12),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: vm.tab == FindAccountTab.id ? const _FindIdForm() : const _ResetPasswordForm(),
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FindAccountTabs extends StatelessWidget {
+  final FindAccountTab tab;
+  final ValueChanged<FindAccountTab>? onChanged;
+
+  const _FindAccountTabs({required this.tab, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    Widget tabButton({required String label, required FindAccountTab value}) {
+      final active = tab == value;
+      return Expanded(
+        child: InkWell(
+          onTap: onChanged == null ? null : () => onChanged!(value),
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 10),
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(
+                  color: active ? const Color(0xFFF97316) : const Color(0xFFE5E7EB),
+                  width: active ? 2 : 1,
+                ),
+              ),
+            ),
+            child: Text(
+              label,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: active ? const Color(0xFFF97316) : const Color(0xFF9CA3AF),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Row(
+      children: [
+        tabButton(label: '아이디 찾기', value: FindAccountTab.id),
+        tabButton(label: '비밀번호 찾기', value: FindAccountTab.pw),
+      ],
+    );
+  }
+}
+
+class _FindIdForm extends StatelessWidget {
+  const _FindIdForm();
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<FindAccountViewModel>();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextField(
+          decoration: const InputDecoration(hintText: '이름', border: UnderlineInputBorder()),
+          onChanged: vm.setName,
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          decoration: const InputDecoration(hintText: '이메일', border: UnderlineInputBorder()),
+          onChanged: vm.setEmail,
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          height: 48,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFF97316),
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            ).copyWith(
+              backgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.disabled)) return const Color(0xFFF97316).withValues(alpha: 0.4);
+                return const Color(0xFFF97316);
+              }),
+            ),
+            onPressed: (vm.name.trim().isNotEmpty && vm.email.trim().isNotEmpty && !vm.loading) ? vm.findId : null,
+            child: vm.loading
+                ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                : const Text('확인', style: TextStyle(fontWeight: FontWeight.w600)),
+          ),
+        ),
+        if (vm.foundUserId != null) ...[
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: const Color(0xFFF9FAFB),
+              border: Border.all(color: const Color(0xFFE5E7EB)),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text('입력하신 회원정보와 일치하는 아이디는 ${vm.foundUserId} 입니다.'),
+          ),
+        ],
+        if (vm.error != null) ...[
+          const SizedBox(height: 10),
+          Text(vm.error!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+        ],
+      ],
+    );
+  }
+}
+
+class _ResetPasswordForm extends StatelessWidget {
+  const _ResetPasswordForm();
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<FindAccountViewModel>();
+
+    final domain = vm.resetEmail.contains('@') ? vm.resetEmail.split('@').last : '';
+    final mailLinkText = domain.isNotEmpty ? '메일함 열기 (mail.$domain)' : '메일함 열기 (mail.sch.ac.kr)';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text('이메일', style: TextStyle(fontSize: 14, color: Color(0xFF374151))),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                keyboardType: TextInputType.emailAddress,
+                decoration: const InputDecoration(
+                  hintText: '예) cheonbab@cheon.ac.kr',
+                  border: UnderlineInputBorder(),
+                ),
+                onChanged: vm.setResetEmail,
+              ),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              height: 40,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFF97316),
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                ).copyWith(
+                  backgroundColor: WidgetStateProperty.resolveWith((states) {
+                    if (states.contains(WidgetState.disabled)) return const Color(0xFFF97316).withValues(alpha: 0.5);
+                    return const Color(0xFFF97316);
+                  }),
+                ),
+                onPressed: (vm.resetEmail.trim().isNotEmpty && !vm.loading) ? vm.requestResetEmail : null,
+                child: vm.loading
+                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                    : const Text('인증 요청', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+              ),
+            ),
+          ],
+        ),
+        if (vm.error != null) ...[
+          const SizedBox(height: 8),
+          Text(vm.error!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+        ],
+        if (vm.success != null) ...[
+          const SizedBox(height: 8),
+          Text('✅ ${vm.success!}', style: const TextStyle(fontSize: 12, color: Color(0xFF16A34A))),
+        ],
+        if (vm.emailSent) ...[
+          const SizedBox(height: 16),
+          const Text('인증 코드', style: TextStyle(fontSize: 14, color: Color(0xFF374151))),
+          const SizedBox(height: 8),
+          TextField(
+            decoration: const InputDecoration(
+              hintText: '메일로 받은 인증 코드 입력',
+              border: UnderlineInputBorder(),
+            ),
+            onChanged: vm.setToken,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            mailLinkText,
+            style: const TextStyle(fontSize: 12, color: Color(0xFF2563EB), decoration: TextDecoration.underline),
+          ),
+        ],
+        const SizedBox(height: 18),
+        const Text('새 비밀번호', style: TextStyle(fontSize: 14, color: Color(0xFF374151))),
+        const SizedBox(height: 8),
+        TextField(
+          obscureText: true,
+          decoration: const InputDecoration(hintText: '새 비밀번호', border: UnderlineInputBorder()),
+          onChanged: vm.setNewPw,
+        ),
+        const SizedBox(height: 16),
+        const Text('비밀번호 확인', style: TextStyle(fontSize: 14, color: Color(0xFF374151))),
+        const SizedBox(height: 8),
+        TextField(
+          obscureText: true,
+          decoration: const InputDecoration(hintText: '새 비밀번호 확인', border: UnderlineInputBorder()),
+          onChanged: vm.setNewPw2,
+        ),
+        const SizedBox(height: 16),
+        SizedBox(
+          height: 48,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFF97316),
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            ).copyWith(
+              backgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.disabled)) return const Color(0xFFF97316).withValues(alpha: 0.5);
+                return const Color(0xFFF97316);
+              }),
+            ),
+            onPressed: (vm.token.trim().isNotEmpty && vm.newPw.isNotEmpty && vm.newPw2.isNotEmpty && !vm.verifying)
+                ? () async {
+                    await vm.confirmResetPassword();
+                    if (!context.mounted) return;
+                    if (vm.error == null && vm.success != null) {
+                      Navigator.of(context).pushReplacementNamed('/');
+                    }
+                  }
+                : null,
+            child: vm.verifying
+                ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                : const Text('비밀번호 변경', style: TextStyle(fontWeight: FontWeight.w600)),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/role.dart';
+import '../viewmodels/login_view_model.dart';
+
+class LoginScreen extends StatelessWidget {
+  static const routeName = '/login';
+
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<LoginViewModel>();
+    final isStudent = vm.role == Role.student;
+    final primary = isStudent ? const Color(0xFFF97316) : const Color(0xFF60A5FA);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(''),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pushReplacementNamed('/'),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _RoleTabs(
+                role: vm.role,
+                onChanged: vm.loading ? null : vm.setRole,
+              ),
+              const SizedBox(height: 18),
+              _HeroCopy(role: vm.role),
+              const SizedBox(height: 18),
+              Form(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const _LabeledTextField(
+                      label: '아이디',
+                      hint: '학번 8자리를 입력해주세요',
+                      keyboardType: TextInputType.number,
+                    ),
+                    const SizedBox(height: 12),
+                    _PasswordField(
+                      enabled: !vm.loading,
+                      onChanged: vm.setPassword,
+                      errorText: vm.errorMessage,
+                    ),
+                    const SizedBox(height: 16),
+                    AnimatedContainer(
+                      duration: const Duration(milliseconds: 250),
+                      curve: Curves.easeInOut,
+                      decoration: BoxDecoration(
+                        color: vm.canSubmit ? primary : primary.withValues(alpha: 0.5),
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                      child: SizedBox(
+                        height: 48,
+                        child: TextButton(
+                          onPressed: vm.canSubmit
+                              ? () async {
+                                  final role = await vm.submit();
+                                  if (!context.mounted || role == null) return;
+                                  Navigator.of(context).pushReplacementNamed(
+                                    role == Role.admin ? '/admin' : '/',
+                                  );
+                                }
+                              : null,
+                          child: vm.loading
+                              ? const SizedBox(
+                                  height: 18,
+                                  width: 18,
+                                  child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                                )
+                              : const Text(
+                                  '로그인',
+                                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
+                                ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    _BottomLinks(enabled: !vm.loading),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RoleTabs extends StatelessWidget {
+  final Role role;
+  final ValueChanged<Role>? onChanged;
+
+  const _RoleTabs({required this.role, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _RoleTabButton(
+            label: '일반',
+            active: role == Role.student,
+            activeColor: const Color(0xFFF97316),
+            onTap: onChanged == null ? null : () => onChanged!(Role.student),
+          ),
+        ),
+        Expanded(
+          child: _RoleTabButton(
+            label: '관리자',
+            active: role == Role.admin,
+            activeColor: const Color(0xFF60A5FA),
+            onTap: onChanged == null ? null : () => onChanged!(Role.admin),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RoleTabButton extends StatelessWidget {
+  final String label;
+  final bool active;
+  final Color activeColor;
+  final VoidCallback? onTap;
+
+  const _RoleTabButton({
+    required this.label,
+    required this.active,
+    required this.activeColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 10),
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: Color(0xFFE5E7EB), width: 1)),
+        ),
+        child: Stack(
+          alignment: Alignment.bottomCenter,
+          children: [
+            Center(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: active ? const Color(0xFF111827) : const Color(0xFF9CA3AF),
+                ),
+              ),
+            ),
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 250),
+              height: 2,
+              width: active ? 80 : 0,
+              margin: const EdgeInsets.only(top: 26),
+              decoration: BoxDecoration(color: active ? activeColor : Colors.transparent),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeroCopy extends StatelessWidget {
+  final Role role;
+  const _HeroCopy({required this.role});
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin = role == Role.admin;
+    return Column(
+      crossAxisAlignment: isAdmin ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+      children: [
+        Text(
+          isAdmin ? '당신의 준비가\n늘 편리하도록,' : '당신의 걸음이\n헛되지 않도록,',
+          textAlign: isAdmin ? TextAlign.right : TextAlign.left,
+          style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w700, height: 1.25),
+        ),
+        const SizedBox(height: 10),
+        // 웹은 Textlogo.png를 쓰지만, 앱 레포에 동일 에셋이 아직 없어서 1차는 텍스트로 대체.
+        Text(
+          '오늘순밥',
+          style: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w800,
+            color: isAdmin ? const Color(0xFF111827) : const Color(0xFF111827),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _LabeledTextField extends StatelessWidget {
+  final String label;
+  final String hint;
+  final TextInputType? keyboardType;
+
+  const _LabeledTextField({required this.label, required this.hint, this.keyboardType});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<LoginViewModel>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: const TextStyle(fontSize: 14, color: Color(0xFF4B5563))),
+        const SizedBox(height: 8),
+        TextField(
+          enabled: !vm.loading,
+          keyboardType: keyboardType,
+          decoration: InputDecoration(
+            hintText: vm.role == Role.student ? hint : '아이디를 입력해주세요',
+            border: const UnderlineInputBorder(),
+          ),
+          onChanged: vm.setUserId,
+        ),
+      ],
+    );
+  }
+}
+
+class _PasswordField extends StatelessWidget {
+  final bool enabled;
+  final ValueChanged<String> onChanged;
+  final String? errorText;
+
+  const _PasswordField({required this.enabled, required this.onChanged, required this.errorText});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('비밀번호', style: TextStyle(fontSize: 14, color: Color(0xFF4B5563))),
+        const SizedBox(height: 8),
+        TextField(
+          enabled: enabled,
+          obscureText: true,
+          decoration: const InputDecoration(border: UnderlineInputBorder()),
+          onChanged: onChanged,
+        ),
+        if (errorText != null) ...[
+          const SizedBox(height: 6),
+          Text(errorText!, style: const TextStyle(fontSize: 12, color: Color(0xFFEF4444))),
+        ],
+      ],
+    );
+  }
+}
+
+class _BottomLinks extends StatelessWidget {
+  final bool enabled;
+  const _BottomLinks({required this.enabled});
+
+  @override
+  Widget build(BuildContext context) {
+    final style = TextButton.styleFrom(
+      foregroundColor: const Color(0xFF6B7280),
+      textStyle: const TextStyle(fontSize: 12),
+      padding: EdgeInsets.zero,
+      minimumSize: const Size(0, 0),
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        TextButton(
+          onPressed: enabled ? () => Navigator.of(context).pushNamed('/find-account', arguments: 'id') : null,
+          style: style,
+          child: const Text('아이디 찾기'),
+        ),
+        const Text('|', style: TextStyle(fontSize: 12, color: Color(0xFFD1D5DB))),
+        TextButton(
+          onPressed: enabled ? () => Navigator.of(context).pushNamed('/find-account', arguments: 'pw') : null,
+          style: style,
+          child: const Text('비밀번호 찾기'),
+        ),
+        const Text('|', style: TextStyle(fontSize: 12, color: Color(0xFFD1D5DB))),
+        TextButton(
+          onPressed: enabled ? () => Navigator.of(context).pushNamed('/signup') : null,
+          style: style,
+          child: const Text('회원가입'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/viewmodels/find_account_view_model.dart
+++ b/lib/features/auth/viewmodels/find_account_view_model.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../models/account_recovery_models.dart';
+import '../repositories/auth_repository.dart';
+
+enum FindAccountTab { id, pw }
+
+class FindAccountViewModel extends ChangeNotifier {
+  FindAccountViewModel(this._repo);
+
+  final AuthRepository _repo;
+
+  FindAccountTab tab = FindAccountTab.id;
+
+  bool loading = false;
+  bool verifying = false;
+  String? error;
+  String? success;
+
+  // Find ID
+  String name = '';
+  String email = '';
+  String? foundUserId;
+
+  // Reset password
+  String resetEmail = '';
+  String token = '';
+  String newPw = '';
+  String newPw2 = '';
+  bool emailSent = false;
+
+  void initTabFromArgs(Object? args) {
+    if (args is String && args == 'pw') {
+      tab = FindAccountTab.pw;
+    } else {
+      tab = FindAccountTab.id;
+    }
+    notifyListeners();
+  }
+
+  void setTab(FindAccountTab v) {
+    tab = v;
+    error = null;
+    success = null;
+    foundUserId = null;
+    notifyListeners();
+  }
+
+  void setName(String v) {
+    name = v;
+    notifyListeners();
+  }
+
+  void setEmail(String v) {
+    email = v;
+    notifyListeners();
+  }
+
+  Future<void> findId() async {
+    if (loading) return;
+    loading = true;
+    error = null;
+    success = null;
+    foundUserId = null;
+    notifyListeners();
+    try {
+      final res = await _repo.findUserId(name: name.trim(), email: email.trim());
+      foundUserId = res.userId;
+    } catch (e) {
+      error = e is ApiException ? mapErrorToMessage(e, responseData: e.details) : '아이디를 찾을 수 없습니다.';
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  void setResetEmail(String v) {
+    resetEmail = v;
+    notifyListeners();
+  }
+
+  void setToken(String v) {
+    token = v;
+    notifyListeners();
+  }
+
+  void setNewPw(String v) {
+    newPw = v;
+    notifyListeners();
+  }
+
+  void setNewPw2(String v) {
+    newPw2 = v;
+    notifyListeners();
+  }
+
+  Future<void> requestResetEmail() async {
+    if (loading) return;
+    loading = true;
+    error = null;
+    success = null;
+    notifyListeners();
+    try {
+      await _repo.resetPasswordRequest(resetEmail.trim());
+      emailSent = true;
+      success = '인증 메일이 발송되었습니다.';
+    } catch (e) {
+      error = e is ApiException ? mapErrorToMessage(e, responseData: e.details) : '메일 발송 실패';
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> confirmResetPassword() async {
+    if (verifying) return;
+    error = null;
+    success = null;
+    if (newPw != newPw2) {
+      error = '비밀번호가 일치하지 않습니다.';
+      notifyListeners();
+      return;
+    }
+    verifying = true;
+    notifyListeners();
+    try {
+      await _repo.resetPasswordConfirm(
+        ResetPasswordConfirmRequest(
+          email: resetEmail.trim(),
+          token: token.trim(),
+          newPassword: newPw,
+          confirmPassword: newPw2,
+        ),
+      );
+      success = '비밀번호가 변경되었습니다.';
+    } catch (e) {
+      error = e is ApiException ? mapErrorToMessage(e, responseData: e.details) : '재설정 실패';
+    } finally {
+      verifying = false;
+      notifyListeners();
+    }
+  }
+}
+
+

--- a/lib/features/auth/viewmodels/login_view_model.dart
+++ b/lib/features/auth/viewmodels/login_view_model.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../models/role.dart';
+import '../repositories/auth_repository.dart';
+
+class LoginViewModel extends ChangeNotifier {
+  final AuthRepository _repo;
+
+  LoginViewModel(this._repo);
+
+  Role role = Role.student;
+  String userId = '';
+  String password = '';
+
+  bool loading = false;
+  String? errorMessage;
+
+  void setRole(Role v) {
+    role = v;
+    notifyListeners();
+  }
+
+  void setUserId(String v) {
+    userId = v;
+    notifyListeners();
+  }
+
+  void setPassword(String v) {
+    password = v;
+    notifyListeners();
+  }
+
+  bool get canSubmit => !loading && userId.trim().isNotEmpty && password.isNotEmpty;
+
+  /// 성공 시 role 반환(라우팅 분기용)
+  Future<Role?> submit() async {
+    if (!canSubmit) return null;
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final meRole = await _repo.login(role: role, userId: userId.trim(), password: password);
+      return meRole;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '로그인에 실패했습니다.';
+      }
+      return null;
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/auth/viewmodels/signup_view_model.dart
+++ b/lib/features/auth/viewmodels/signup_view_model.dart
@@ -1,0 +1,306 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../models/role.dart';
+import '../models/signup_models.dart';
+import '../repositories/auth_repository.dart';
+
+class SignupDraft {
+  final String? id;
+  final String? name;
+  final String? email;
+  final String? password;
+  final bool? agreeTos;
+  final bool? agreePrivacy;
+
+  const SignupDraft({
+    this.id,
+    this.name,
+    this.email,
+    this.password,
+    this.agreeTos,
+    this.agreePrivacy,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'email': email,
+        'password': password,
+        'agreeTos': agreeTos,
+        'agreePrivacy': agreePrivacy,
+      };
+
+  factory SignupDraft.fromJson(Map<String, dynamic> json) {
+    return SignupDraft(
+      id: json['id']?.toString(),
+      name: json['name']?.toString(),
+      email: json['email']?.toString(),
+      password: json['password']?.toString(),
+      agreeTos: json['agreeTos'] == true,
+      agreePrivacy: json['agreePrivacy'] == true,
+    );
+  }
+}
+
+class SignupViewModel extends ChangeNotifier {
+  SignupViewModel(this._repo);
+
+  static const _draftKey = 'signup_draft_v1';
+
+  final AuthRepository _repo;
+
+  // Step1: ID
+  String id = '';
+  bool checkingId = false;
+  bool? idOk;
+  String? idErrorMessage;
+
+  // Step2/3: credentials
+  String name = '';
+  String pw = '';
+  String pw2 = '';
+  String email = '';
+
+  bool agreeTos = false;
+  bool agreePrivacy = false;
+
+  // email verification
+  bool emailSent = false;
+  String emailCode = '';
+  bool verified = false;
+  bool sendingEmail = false;
+  bool verifyingEmail = false;
+  String? emailError;
+
+  bool submitting = false;
+  String? submitError;
+
+  // 요구사항: 8~16자, 영문/숫자/특수문자 모두 포함(공백 불가)
+  final RegExp pwdRule = RegExp(
+    r'^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*().,_-])[A-Za-z\d!@#$%^&*().,_-]{8,16}$',
+  );
+
+  bool get validPwd => pwdRule.hasMatch(pw) && !pw.contains(RegExp(r'\s'));
+  bool get samePwd => pw.isNotEmpty && pw == pw2;
+
+  bool get validEmail =>
+      RegExp(r'^[^\s@]+@[^\s@]+\.[^\s@]+$').hasMatch(email) && email.trim().endsWith('@sch.ac.kr');
+
+  bool get canNextFromId => idOk == true && !checkingId;
+
+  bool get canSubmit =>
+      name.trim().isNotEmpty &&
+      validPwd &&
+      samePwd &&
+      validEmail &&
+      verified &&
+      agreeTos &&
+      agreePrivacy;
+
+  Future<void> loadDraft() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_draftKey);
+    if (raw == null || raw.isEmpty) return;
+    try {
+      final json = jsonDecode(raw) as Map<String, dynamic>;
+      final d = SignupDraft.fromJson(json);
+      if (d.id != null) id = d.id!;
+      name = d.name ?? name;
+      email = d.email ?? email;
+      pw = d.password ?? pw;
+      pw2 = d.password ?? pw2;
+      agreeTos = d.agreeTos ?? agreeTos;
+      agreePrivacy = d.agreePrivacy ?? agreePrivacy;
+      notifyListeners();
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  Future<void> saveDraft() async {
+    final prefs = await SharedPreferences.getInstance();
+    final draft = SignupDraft(
+      id: id.isEmpty ? null : id,
+      name: name.isEmpty ? null : name,
+      email: email.isEmpty ? null : email,
+      password: pw.isEmpty ? null : pw,
+      agreeTos: agreeTos,
+      agreePrivacy: agreePrivacy,
+    );
+    await prefs.setString(_draftKey, jsonEncode(draft.toJson()));
+  }
+
+  Future<void> clearDraft() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_draftKey);
+  }
+
+  Future<void> onChangeId(String v) async {
+    id = v;
+    idOk = null;
+    idErrorMessage = null;
+    notifyListeners();
+
+    if (RegExp(r'^.{8}$').hasMatch(v)) {
+      checkingId = true;
+      notifyListeners();
+      try {
+        final res = await _repo.verifyId(v);
+        idOk = res.valid;
+        if (!res.valid) idErrorMessage = res.message;
+      } catch (e) {
+        idOk = false;
+        idErrorMessage = '아이디 확인 중 오류가 발생했습니다.';
+      } finally {
+        checkingId = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  void setName(String v) {
+    name = v;
+    notifyListeners();
+  }
+
+  void setPw(String v) {
+    pw = v;
+    notifyListeners();
+  }
+
+  void setPw2(String v) {
+    pw2 = v;
+    notifyListeners();
+  }
+
+  void setEmail(String v) {
+    email = v;
+    // 이메일 바뀌면 인증 상태 초기화(웹 동작과 동일)
+    verified = false;
+    emailSent = false;
+    emailCode = '';
+    emailError = null;
+    notifyListeners();
+  }
+
+  void setAgreeTos(bool v) {
+    agreeTos = v;
+    notifyListeners();
+  }
+
+  void setAgreePrivacy(bool v) {
+    agreePrivacy = v;
+    notifyListeners();
+  }
+
+  void setAgreeAll(bool v) {
+    agreeTos = v;
+    agreePrivacy = v;
+    notifyListeners();
+  }
+
+  void setEmailCode(String v) {
+    emailCode = v;
+    notifyListeners();
+  }
+
+  Future<void> sendEmail() async {
+    if (!validEmail) {
+      emailError = '이메일은 @sch.ac.kr 형식이어야 합니다.';
+      notifyListeners();
+      return;
+    }
+
+    sendingEmail = true;
+    emailError = null;
+    notifyListeners();
+
+    try {
+      final alreadyRegistered = await _repo.getSignupEmailStatus(email);
+      if (alreadyRegistered) {
+        emailError = '이미 가입된 이메일입니다.';
+        return;
+      }
+
+      emailSent = false;
+      emailCode = '';
+      verified = false;
+
+      await _repo.sendEmailVerification(email);
+      emailSent = true;
+    } catch (e) {
+      if (e is ApiException) {
+        emailError = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        emailError = '메일 발송 실패';
+      }
+    } finally {
+      sendingEmail = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> verifyEmailCode() async {
+    if (!emailSent) return;
+    if (emailCode.trim().isEmpty) return;
+
+    verifyingEmail = true;
+    emailError = null;
+    notifyListeners();
+
+    try {
+      await _repo.verifyEmail(email: email, code: emailCode.trim());
+      verified = true;
+      await saveDraft();
+    } catch (e) {
+      verified = false;
+      if (e is ApiException) {
+        emailError = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        emailError = '인증 실패';
+      }
+    } finally {
+      verifyingEmail = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> submit() async {
+    if (!canSubmit) return false;
+
+    submitting = true;
+    submitError = null;
+    notifyListeners();
+
+    try {
+      await _repo.signUp(
+        SignUpRequest(
+          role: Role.student,
+          userId: id,
+          name: name.trim(),
+          email: email.trim(),
+          password: pw,
+        ),
+      );
+      await clearDraft();
+      return true;
+    } catch (e) {
+      if (e is ApiException) {
+        submitError = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        submitError = '회원가입 실패';
+      }
+      return false;
+    } finally {
+      submitting = false;
+      notifyListeners();
+    }
+  }
+}
+
+

--- a/lib/features/common/screens/placeholder_screen.dart
+++ b/lib/features/common/screens/placeholder_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class PlaceholderScreen extends StatelessWidget {
+  final String title;
+
+  const PlaceholderScreen({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Center(
+        child: Text(
+          '$title (임시 화면)',
+          style: const TextStyle(fontSize: 16),
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/lib/features/signup/screens/signup_credentials_screen.dart
+++ b/lib/features/signup/screens/signup_credentials_screen.dart
@@ -1,0 +1,525 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auth/viewmodels/signup_view_model.dart';
+import 'signup_terms_screen.dart';
+
+class SignupCredentialsScreen extends StatefulWidget {
+  static const routeName = '/signup/credentials';
+
+  const SignupCredentialsScreen({super.key});
+
+  @override
+  State<SignupCredentialsScreen> createState() => _SignupCredentialsScreenState();
+}
+
+class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final vm = context.read<SignupViewModel>();
+      await vm.loadDraft();
+      if (!mounted) return;
+      if (vm.id.trim().isEmpty) {
+        Navigator.of(context).pushReplacementNamed('/signup/id');
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<SignupViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const _SignupHeader(),
+                const SizedBox(height: 28),
+                _InputName(
+                  value: vm.name,
+                  onChanged: vm.setName,
+                ),
+                const SizedBox(height: 18),
+                _InputPassword(
+                  pw: vm.pw,
+                  pw2: vm.pw2,
+                  validPwd: vm.validPwd,
+                  samePwd: vm.samePwd,
+                  onChangedPw: vm.setPw,
+                  onChangedPw2: vm.setPw2,
+                ),
+                const SizedBox(height: 18),
+                _InputEmail(
+                  email: vm.email,
+                  onChanged: vm.setEmail,
+                  sending: vm.sendingEmail,
+                  verifying: vm.verifyingEmail,
+                  emailSent: vm.emailSent,
+                  code: vm.emailCode,
+                  verified: vm.verified,
+                  error: vm.emailError,
+                  onSend: vm.sendEmail,
+                  onChangeCode: vm.setEmailCode,
+                  onVerify: vm.verifyEmailCode,
+                ),
+                const SizedBox(height: 18),
+                _Agreements(
+                  agreeTos: vm.agreeTos,
+                  agreePrivacy: vm.agreePrivacy,
+                  onToggleAll: vm.setAgreeAll,
+                  onToggleTos: vm.setAgreeTos,
+                  onTogglePrivacy: vm.setAgreePrivacy,
+                ),
+                if (vm.submitError != null) ...[
+                  const SizedBox(height: 12),
+                  Text(vm.submitError!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+                ],
+                const SizedBox(height: 18),
+                SizedBox(
+                  height: 48,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFF97316),
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                    ).copyWith(
+                      backgroundColor: WidgetStateProperty.resolveWith((states) {
+                        if (states.contains(WidgetState.disabled)) {
+                          return const Color(0xFFF97316).withValues(alpha: 0.4);
+                        }
+                        return const Color(0xFFF97316);
+                      }),
+                    ),
+                    onPressed: (!vm.submitting && vm.canSubmit)
+                        ? () async {
+                            await vm.saveDraft();
+                            final ok = await vm.submit();
+                            if (!context.mounted) return;
+                            if (ok) {
+                              Navigator.of(context).pushReplacementNamed('/login');
+                            }
+                          }
+                        : null,
+                    child: vm.submitting
+                        ? const SizedBox(
+                            height: 18,
+                            width: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                          )
+                        : const Text('본인 인증 후 가입하기', style: TextStyle(fontWeight: FontWeight.w600)),
+                  ),
+                ),
+                const SizedBox(height: 12),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignupHeader extends StatelessWidget {
+  const _SignupHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '천밥에 오신 것을\n환영합니다!',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700, height: 1.25),
+        ),
+        const SizedBox(height: 8),
+        RichText(
+          text: TextSpan(
+            style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+            children: [
+              TextSpan(text: '1분', style: TextStyle(color: Color(0xFFF97316), fontWeight: FontWeight.w600)),
+              TextSpan(text: '이면 회원가입 가능해요'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InputName extends StatelessWidget {
+  final String value;
+  final ValueChanged<String> onChanged;
+
+  const _InputName({required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: const TextSpan(
+            style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
+            children: [
+              TextSpan(text: '이름 '),
+              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          decoration: const InputDecoration(
+            hintText: '이름을 입력해주세요',
+            border: UnderlineInputBorder(),
+          ),
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _InputPassword extends StatelessWidget {
+  final String pw;
+  final String pw2;
+  final bool validPwd;
+  final bool samePwd;
+  final ValueChanged<String> onChangedPw;
+  final ValueChanged<String> onChangedPw2;
+
+  const _InputPassword({
+    required this.pw,
+    required this.pw2,
+    required this.validPwd,
+    required this.samePwd,
+    required this.onChangedPw,
+    required this.onChangedPw2,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: const TextSpan(
+            style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
+            children: [
+              TextSpan(text: '비밀번호 '),
+              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          obscureText: true,
+          decoration: const InputDecoration(
+            hintText: '8~16자 영문·숫자·특수문자 조합',
+            border: UnderlineInputBorder(),
+          ),
+          onChanged: onChangedPw,
+        ),
+        if (pw.isNotEmpty && !validPwd) ...[
+          const SizedBox(height: 6),
+          Row(
+            children: const [
+              Icon(Icons.error_outline, size: 16, color: Color(0xFFDC2626)),
+              SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  '비밀번호는 8~16자의 영문, 숫자, 특수문자를 모두 포함해야 합니다.',
+                  style: TextStyle(fontSize: 12, color: Color(0xFFDC2626)),
+                ),
+              ),
+            ],
+          ),
+        ],
+        const SizedBox(height: 16),
+        RichText(
+          text: const TextSpan(
+            style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
+            children: [
+              TextSpan(text: '비밀번호 확인 '),
+              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          obscureText: true,
+          decoration: const InputDecoration(border: UnderlineInputBorder()),
+          onChanged: onChangedPw2,
+        ),
+        if (pw2.isNotEmpty && !samePwd) ...[
+          const SizedBox(height: 6),
+          Row(
+            children: const [
+              Icon(Icons.error_outline, size: 16, color: Color(0xFFDC2626)),
+              SizedBox(width: 6),
+              Text('비밀번호를 다시 확인해주세요', style: TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _InputEmail extends StatelessWidget {
+  final String email;
+  final ValueChanged<String> onChanged;
+  final bool sending;
+  final bool verifying;
+  final bool emailSent;
+  final String code;
+  final bool verified;
+  final String? error;
+  final VoidCallback onSend;
+  final ValueChanged<String> onChangeCode;
+  final VoidCallback onVerify;
+
+  const _InputEmail({
+    required this.email,
+    required this.onChanged,
+    required this.sending,
+    required this.verifying,
+    required this.emailSent,
+    required this.code,
+    required this.verified,
+    required this.error,
+    required this.onSend,
+    required this.onChangeCode,
+    required this.onVerify,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isSch = email.trim().endsWith('@sch.ac.kr');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RichText(
+          text: const TextSpan(
+            style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
+            children: [
+              TextSpan(text: '이메일 주소 '),
+              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                keyboardType: TextInputType.emailAddress,
+                decoration: const InputDecoration(
+                  hintText: '예) cheonbab@sch.ac.kr',
+                  border: UnderlineInputBorder(),
+                ),
+                onChanged: onChanged,
+              ),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              height: 40,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFF97316),
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                ).copyWith(
+                  backgroundColor: WidgetStateProperty.resolveWith((states) {
+                    if (states.contains(WidgetState.disabled)) {
+                      return const Color(0xFFF97316).withValues(alpha: 0.5);
+                    }
+                    return const Color(0xFFF97316);
+                  }),
+                ),
+                onPressed: (email.isNotEmpty && isSch && !sending) ? onSend : null,
+                child: sending
+                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                    : const Text('인증 요청', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+              ),
+            ),
+          ],
+        ),
+        if (emailSent) ...[
+          const SizedBox(height: 12),
+          const Text('인증 코드', style: TextStyle(fontSize: 14, color: Color(0xFF374151))),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  decoration: const InputDecoration(border: UnderlineInputBorder()),
+                  onChanged: onChangeCode,
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 40,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF22C55E),
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                  ).copyWith(
+                    backgroundColor: WidgetStateProperty.resolveWith((states) {
+                      if (states.contains(WidgetState.disabled)) {
+                        return const Color(0xFF22C55E).withValues(alpha: 0.5);
+                      }
+                      return const Color(0xFF22C55E);
+                    }),
+                  ),
+                  onPressed: (code.isNotEmpty && !verifying) ? onVerify : null,
+                  child: verifying
+                      ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                      : const Text('확인', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          InkWell(
+            onTap: () {
+              // iOS/Android에서 기본 브라우저로 열기(간단히 시스템 처리)
+              // 실제로는 url_launcher를 쓰는 게 정석이지만, 현재 의존성 추가 없이 UI만 먼저 맞춤.
+            },
+            child: const Text(
+              '메일함 열기 (mail.sch.ac.kr)',
+              style: TextStyle(fontSize: 12, color: Color(0xFF2563EB), decoration: TextDecoration.underline),
+            ),
+          ),
+          if (verified) ...[
+            const SizedBox(height: 8),
+            const Text('✅ 인증 완료', style: TextStyle(fontSize: 12, color: Color(0xFF16A34A))),
+          ],
+        ],
+        if (error != null) ...[
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Icon(Icons.error_outline, size: 16, color: Color(0xFFDC2626)),
+              const SizedBox(width: 6),
+              Expanded(child: Text(error!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626)))),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _Agreements extends StatelessWidget {
+  final bool agreeTos;
+  final bool agreePrivacy;
+  final ValueChanged<bool> onToggleAll;
+  final ValueChanged<bool> onToggleTos;
+  final ValueChanged<bool> onTogglePrivacy;
+
+  const _Agreements({
+    required this.agreeTos,
+    required this.agreePrivacy,
+    required this.onToggleAll,
+    required this.onToggleTos,
+    required this.onTogglePrivacy,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final agreeAll = agreeTos && agreePrivacy;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        InkWell(
+          onTap: () => onToggleAll(!agreeAll),
+          child: Row(
+            children: [
+              Checkbox(
+                value: agreeAll,
+                onChanged: (v) => onToggleAll(v ?? false),
+                activeColor: const Color(0xFFF97316),
+              ),
+              const SizedBox(width: 6),
+              const Text('모두 동의합니다', style: TextStyle(fontWeight: FontWeight.w600)),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.only(left: 12),
+          child: Column(
+            children: [
+              _AgreementRow(
+                checked: agreeTos,
+                label: '[필수] 이용약관 동의',
+                onToggle: onToggleTos,
+                onView: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const SignupTermsScreen(doc: 'tos')),
+                ),
+              ),
+              const SizedBox(height: 8),
+              _AgreementRow(
+                checked: agreePrivacy,
+                label: '[필수] 개인 정보 수집 및 이용 동의',
+                onToggle: onTogglePrivacy,
+                onView: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const SignupTermsScreen(doc: 'privacy')),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AgreementRow extends StatelessWidget {
+  final bool checked;
+  final String label;
+  final ValueChanged<bool> onToggle;
+  final VoidCallback onView;
+
+  const _AgreementRow({required this.checked, required this.label, required this.onToggle, required this.onView});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Checkbox(
+          value: checked,
+          onChanged: (v) => onToggle(v ?? false),
+          activeColor: const Color(0xFFF97316),
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+        ),
+        Expanded(
+          child: Text(label, style: const TextStyle(fontSize: 12, color: Color(0xFF374151))),
+        ),
+        TextButton(
+          onPressed: onView,
+          style: TextButton.styleFrom(
+            foregroundColor: const Color(0xFF6B7280),
+            textStyle: const TextStyle(fontSize: 12),
+            padding: EdgeInsets.zero,
+            minimumSize: const Size(0, 0),
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          child: const Text('내용 보기 >'),
+        ),
+      ],
+    );
+  }
+}
+
+/// 간단 라우터: 아직 main.dart 라우트 연결 전이라 credentials 화면 내부에서만 사용.
+

--- a/lib/features/signup/screens/signup_id_screen.dart
+++ b/lib/features/signup/screens/signup_id_screen.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auth/viewmodels/signup_view_model.dart';
+
+class SignupIdScreen extends StatefulWidget {
+  static const routeName = '/signup/id';
+
+  const SignupIdScreen({super.key});
+
+  @override
+  State<SignupIdScreen> createState() => _SignupIdScreenState();
+}
+
+class _SignupIdScreenState extends State<SignupIdScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<SignupViewModel>().loadDraft();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<SignupViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 0),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const SizedBox(height: 16),
+                  const _SignupHeader(),
+                  const SizedBox(height: 32),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      RichText(
+                        text: const TextSpan(
+                          style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
+                          children: [
+                            TextSpan(text: '아이디'),
+                            TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TextField(
+                        decoration: const InputDecoration(
+                          hintText: '학번 8자리를 입력해주세요',
+                          border: UnderlineInputBorder(),
+                        ),
+                        onChanged: vm.onChangeId,
+                      ),
+                      const SizedBox(height: 8),
+                      if (vm.checkingId)
+                        const Text('중복 확인 중…', style: TextStyle(fontSize: 12, color: Color(0xFF6B7280))),
+                      if (vm.idOk == false && vm.idErrorMessage != null)
+                        Text(vm.idErrorMessage!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+                      if (vm.idOk == true)
+                        const Text('사용가능한 아이디입니다', style: TextStyle(fontSize: 12, color: Color(0xFF16A34A))),
+                    ],
+                  ),
+                  const SizedBox(height: 40),
+                  SizedBox(
+                    height: 48,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFFF97316),
+                        disabledBackgroundColor: const Color(0xFFF97316),
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                      ).copyWith(
+                        backgroundColor: WidgetStateProperty.resolveWith((states) {
+                          if (states.contains(WidgetState.disabled)) {
+                            return const Color(0xFFF97316).withValues(alpha: 0.4);
+                          }
+                          return const Color(0xFFF97316);
+                        }),
+                      ),
+                      onPressed: vm.canNextFromId
+                          ? () async {
+                              await vm.saveDraft();
+                              if (!context.mounted) return;
+                              Navigator.of(context).pushNamed('/signup/credentials');
+                            }
+                          : null,
+                      child: const Text('확인', style: TextStyle(fontWeight: FontWeight.w600)),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SignupHeader extends StatelessWidget {
+  const _SignupHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '천밥에 오신 것을\n환영합니다!',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700, height: 1.25),
+        ),
+        const SizedBox(height: 8),
+        RichText(
+          text: TextSpan(
+            style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+            children: [
+              TextSpan(text: '1분', style: TextStyle(color: Color(0xFFF97316), fontWeight: FontWeight.w600)),
+              TextSpan(text: '이면 회원가입 가능해요'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+

--- a/lib/features/signup/screens/signup_terms_screen.dart
+++ b/lib/features/signup/screens/signup_terms_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class SignupTermsScreen extends StatelessWidget {
+  static const routeName = '/signup/terms';
+
+  final String doc; // 'tos' | 'privacy'
+
+  const SignupTermsScreen({super.key, required this.doc});
+
+  @override
+  Widget build(BuildContext context) {
+    final title = doc == 'privacy' ? '개인정보 수집 및 이용 동의' : '이용약관';
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('약관')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+              const SizedBox(height: 12),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Text(
+                    '여기에 ${doc == 'privacy' ? '개인정보 처리방침' : '이용약관'} 전문을 넣어주세요.\n'
+                    '임시 문구입니다. 추후 마크다운/서버 콘텐츠로 교체 가능합니다.',
+                    style: const TextStyle(fontSize: 14, height: 1.6, color: Color(0xFF374151)),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/lib/features/users/models/me_response.dart
+++ b/lib/features/users/models/me_response.dart
@@ -1,0 +1,13 @@
+import '../../auth/models/role.dart';
+
+class MeResponse {
+  final Role role;
+
+  MeResponse({required this.role});
+
+  factory MeResponse.fromJson(Map<String, dynamic> json) {
+    return MeResponse(role: RoleApi.fromApi((json['role'] ?? 'STUDENT').toString()));
+  }
+}
+
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,9 @@ import 'common/dio/dio_client.dart';
 import 'common/storage/token_storage.dart';
 import 'features/auth/data/auth_api.dart';
 import 'features/auth/repositories/auth_repository.dart';
+import 'features/auth/screens/find_account_screen.dart';
 import 'features/auth/screens/login_screen.dart';
+import 'features/auth/viewmodels/find_account_view_model.dart';
 import 'features/auth/viewmodels/login_view_model.dart';
 import 'features/auth/viewmodels/signup_view_model.dart';
 import 'features/common/screens/placeholder_screen.dart';
@@ -36,6 +38,7 @@ class MyApp extends StatelessWidget {
         Provider.value(value: authRepo),
         ChangeNotifierProvider(create: (_) => LoginViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => SignupViewModel(authRepo)),
+        ChangeNotifierProvider(create: (_) => FindAccountViewModel(authRepo)),
       ],
       child: MaterialApp(
         title: '1000meal App',
@@ -56,7 +59,7 @@ class MyApp extends StatelessWidget {
             final doc = args is String ? args : 'tos';
             return SignupTermsScreen(doc: doc);
           },
-          '/find-account': (_) => const PlaceholderScreen(title: '/find-account'),
+          FindAccountScreen.routeName: (_) => const FindAccountScreen(),
         },
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,11 @@ import 'features/auth/data/auth_api.dart';
 import 'features/auth/repositories/auth_repository.dart';
 import 'features/auth/screens/login_screen.dart';
 import 'features/auth/viewmodels/login_view_model.dart';
+import 'features/auth/viewmodels/signup_view_model.dart';
 import 'features/common/screens/placeholder_screen.dart';
+import 'features/signup/screens/signup_credentials_screen.dart';
+import 'features/signup/screens/signup_id_screen.dart';
+import 'features/signup/screens/signup_terms_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -31,6 +35,7 @@ class MyApp extends StatelessWidget {
       providers: [
         Provider.value(value: authRepo),
         ChangeNotifierProvider(create: (_) => LoginViewModel(authRepo)),
+        ChangeNotifierProvider(create: (_) => SignupViewModel(authRepo)),
       ],
       child: MaterialApp(
         title: '1000meal App',
@@ -41,8 +46,16 @@ class MyApp extends StatelessWidget {
           LoginScreen.routeName: (_) => const LoginScreen(),
           '/': (_) => const PlaceholderScreen(title: '/ (메인)'),
           '/admin': (_) => const PlaceholderScreen(title: '/admin'),
-          // 아래 라우트들은 다음 단계에서 구현 예정(지금은 네비게이션만 막지 않기 위해 placeholder)
-          '/signup': (_) => const PlaceholderScreen(title: '/signup'),
+          // signup
+          '/signup': (_) => const SignupIdScreen(),
+          SignupIdScreen.routeName: (_) => const SignupIdScreen(),
+          SignupCredentialsScreen.routeName: (_) => const SignupCredentialsScreen(),
+          // 약관(웹은 query param doc=tos|privacy)
+          SignupTermsScreen.routeName: (context) {
+            final args = ModalRoute.of(context)?.settings.arguments;
+            final doc = args is String ? args : 'tos';
+            return SignupTermsScreen(doc: doc);
+          },
           '/find-account': (_) => const PlaceholderScreen(title: '/find-account'),
         },
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-void main() {
+import 'common/config/app_config.dart';
+import 'common/dio/dio_client.dart';
+import 'common/storage/token_storage.dart';
+import 'features/auth/data/auth_api.dart';
+import 'features/auth/repositories/auth_repository.dart';
+import 'features/auth/screens/login_screen.dart';
+import 'features/auth/viewmodels/login_view_model.dart';
+import 'features/common/screens/placeholder_screen.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await AppConfig.load();
   runApp(const MyApp());
 }
 
@@ -10,112 +22,29 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: .fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
+    final tokenStorage = TokenStorage();
+    final dioClient = DioClient.create();
+    final authApi = AuthApi(dioClient);
+    final authRepo = AuthRepository(api: authApi, tokenStorage: tokenStorage);
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: .center,
-          children: [
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
+    return MultiProvider(
+      providers: [
+        Provider.value(value: authRepo),
+        ChangeNotifierProvider(create: (_) => LoginViewModel(authRepo)),
+      ],
+      child: MaterialApp(
+        title: '1000meal App',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(useMaterial3: true),
+        initialRoute: LoginScreen.routeName,
+        routes: {
+          LoginScreen.routeName: (_) => const LoginScreen(),
+          '/': (_) => const PlaceholderScreen(title: '/ (메인)'),
+          '/admin': (_) => const PlaceholderScreen(title: '/admin'),
+          // 아래 라우트들은 다음 단계에서 구현 예정(지금은 네비게이션만 막지 않기 위해 placeholder)
+          '/signup': (_) => const PlaceholderScreen(title: '/signup'),
+          '/find-account': (_) => const PlaceholderScreen(title: '/find-account'),
+        },
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,9 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/env/.env
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
> NOTE: 이번 브랜치에서 **이메일 변경은 미구현**하였음.

---

## 연결 이슈
- Closes #3

---

## 배경(Why)
- 기존 웹(Next.js)에서 사용 중인 인증 플로우를 Flutter 앱으로 마이그레이션합니다.
- Flutter 앱 아키텍처는 **MVVM** 기반이며, 상태 관리는 **provider(ChangeNotifier)** 로 통일합니다.
- 토큰은 **flutter_secure_storage**에 저장하고, API 통신은 **dio**로 구성합니다(에러 매핑 포함).

---

## 목표(What)
- 웹과 동일한 기능/검증/에러 처리 UX를 Flutter로 이식합니다.
- Android/iOS에서 정상 동작(시뮬레이터/에뮬레이터 기준)합니다.

---

## 구현 내용(요약)
### Infra
- `.env` 로드(`flutter_dotenv`) 및 API base URL 구성
- `DioClient` 구성 + 공통 에러 매핑(`ApiException` + mapper)
- 토큰 저장소(`TokenStorage` via `flutter_secure_storage`)

### 로그인
- `LoginViewModel` + `LoginScreen` 구현
- role(STUDENT/ADMIN) 선택 UI 및 **탭 전환 애니메이션(밑줄 이동 + 카피 페이드)** 반영
- 로그인 성공 시 토큰 저장 후 `/auth/me`로 role 확인 → `/` 또는 `/admin` 라우팅

### 회원가입(멀티스텝)
- Step A: ID 입력/검증(학번 8자리 + 서버 검증)
- Step B: 약관 동의
- Step C: 자격/이메일 인증/필수 동의 + 가입 제출
- draft 개념을 앱에 맞게 `shared_preferences`로 임시 저장/복원
- 이메일 도메인 제한 `@sch.ac.kr`

### 계정 찾기(탭)
- 탭 UI(아이디 찾기 / 비밀번호 찾기)
- 아이디 찾기: name + email → find-id 결과 표시
- 비밀번호 재설정: 이메일 인증 요청 → 코드 + 새 비밀번호로 확정

---

## API 엔드포인트(백엔드 계약)
### 로그인/내 정보
- POST `/auth/login`
- GET `/auth/me`

### 회원가입
- POST `/signup/user/validate-id`
- POST `/auth/signup`

### 이메일 인증(회원가입)
- POST `/auth/email/send`
- POST `/auth/email/verify`
- GET `/auth/email/status?email=...`

### 계정 찾기
- POST `/auth/find-id`

### 비밀번호 재설정
- POST `/auth/password/reset/request`
- POST `/auth/password/reset/confirm`

---

## 라우팅
- `/login`
- `/signup` (`/signup/id`, `/signup/credentials`, `/signup/terms`)
- `/find-account` (arguments로 기본 탭 id/pw 설정)

---

## 완료 조건(DoD)
- Android/iOS에서 로그인/회원가입/계정찾기 플로우가 끝까지 동작
- 토큰 저장이 `flutter_secure_storage`로 동작(앱 재실행 후 유지)
- 로딩/에러 메시지가 웹과 동등한 수준으로 표시됨
- `flutter analyze` 통과
- 수동 테스트 시나리오 수행 완료

---

## 수동 테스트 시나리오(체크리스트)
- [ ] 로그인 성공/실패(잘못된 비번/없는 계정 등) 메시지 확인
- [ ] 회원가입: ID 검증 실패/성공 → 이메일 인증 실패/성공 → 가입 성공
- [ ] 계정 찾기: 아이디 찾기 성공/실패
- [ ] 비번 재설정: 요청/확정 성공/실패
- [ ] 앱 재실행 후 토큰 유지 확인
- [ ] `flutter analyze` 결과 이상 없음

---

## 비고 / 범위
- **이메일 변경(3단계)은 이번 PR 범위에서 제외**(후속 이슈/브랜치로 분리 예정)
- `API_BASE_URL`(env) 값은 로컬 `.env`로 주입(배포 환경 주입 방식은 별도 확정 필요)
