### PR TITLE
[FEAT] 마이페이지 마이그레이션: 마이페이지 + 회원정보 수정(이메일 변경)

### DIFF
--- a/lib/common/utils/external_link.dart
+++ b/lib/common/utils/external_link.dart
@@ -1,0 +1,10 @@
+import 'package:url_launcher/url_launcher.dart';
+
+Future<bool> openExternalUrl(String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return false;
+  if (!await canLaunchUrl(uri)) return false;
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+

--- a/lib/features/auth/data/auth_api.dart
+++ b/lib/features/auth/data/auth_api.dart
@@ -2,6 +2,7 @@ import '../../../common/dio/dio_client.dart';
 import '../../users/models/me_response.dart';
 import '../models/login_models.dart';
 import '../models/account_recovery_models.dart';
+import '../models/email_change_models.dart';
 import '../models/signup_models.dart';
 
 class AuthApi {
@@ -98,6 +99,52 @@ class AuthApi {
       '/auth/password/reset/confirm',
       data: request.toJson(),
     );
+  }
+
+  Future<void> deleteAccount({required String token, required String currentPassword, required bool agree}) async {
+    await _client.post<Object>(
+      '/auth/delete-account',
+      headers: {'Authorization': 'Bearer $token'},
+      data: {
+        'currentPassword': currentPassword,
+        'agree': agree,
+      },
+    );
+  }
+
+  Future<StartEmailChangeResponse> startEmailChange({
+    required String token,
+    required StartEmailChangeRequest request,
+  }) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/account/email/start',
+      headers: {'Authorization': 'Bearer $token'},
+      data: request.toJson(),
+    );
+    return StartEmailChangeResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<void> sendEmailChangeCode({
+    required String token,
+    required SendEmailChangeCodeRequest request,
+  }) async {
+    await _client.post<Object>(
+      '/account/email/code',
+      headers: {'Authorization': 'Bearer $token'},
+      data: request.toJson(),
+    );
+  }
+
+  Future<VerifyEmailChangeResponse> verifyEmailChange({
+    required String token,
+    required VerifyEmailChangeRequest request,
+  }) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/account/email/verify',
+      headers: {'Authorization': 'Bearer $token'},
+      data: request.toJson(),
+    );
+    return VerifyEmailChangeResponse.fromJson(_unwrapData(root));
   }
 }
 

--- a/lib/features/auth/models/email_change_models.dart
+++ b/lib/features/auth/models/email_change_models.dart
@@ -1,0 +1,62 @@
+class StartEmailChangeRequest {
+  final String currentEmail;
+  final String password;
+
+  StartEmailChangeRequest({required this.currentEmail, required this.password});
+
+  Map<String, dynamic> toJson() => {
+        'currentEmail': currentEmail,
+        'password': password,
+      };
+}
+
+class StartEmailChangeResponse {
+  final String changeId;
+  final int? expiresInSec;
+
+  StartEmailChangeResponse({required this.changeId, this.expiresInSec});
+
+  factory StartEmailChangeResponse.fromJson(Map<String, dynamic> json) {
+    final expires = json['expiresInSec'];
+    return StartEmailChangeResponse(
+      changeId: (json['changeId'] ?? '').toString(),
+      expiresInSec: expires is int ? expires : int.tryParse((expires ?? '').toString()),
+    );
+  }
+}
+
+class SendEmailChangeCodeRequest {
+  final String changeId;
+  final String newEmail;
+
+  SendEmailChangeCodeRequest({required this.changeId, required this.newEmail});
+
+  Map<String, dynamic> toJson() => {
+        'changeId': changeId,
+        'newEmail': newEmail,
+      };
+}
+
+class VerifyEmailChangeRequest {
+  final String changeId;
+  final String code;
+
+  VerifyEmailChangeRequest({required this.changeId, required this.code});
+
+  Map<String, dynamic> toJson() => {
+        'changeId': changeId,
+        'code': code,
+      };
+}
+
+class VerifyEmailChangeResponse {
+  final String? updatedEmail;
+
+  VerifyEmailChangeResponse({this.updatedEmail});
+
+  factory VerifyEmailChangeResponse.fromJson(Map<String, dynamic> json) {
+    return VerifyEmailChangeResponse(updatedEmail: json['updatedEmail']?.toString());
+  }
+}
+
+

--- a/lib/features/auth/repositories/auth_repository.dart
+++ b/lib/features/auth/repositories/auth_repository.dart
@@ -4,6 +4,7 @@ import '../../users/models/me_response.dart';
 import '../data/auth_api.dart';
 import '../models/account_recovery_models.dart';
 import '../models/login_models.dart';
+import '../models/email_change_models.dart';
 import '../models/role.dart';
 import '../models/signup_models.dart';
 
@@ -49,6 +50,39 @@ class AuthRepository {
   Future<void> resetPasswordRequest(String email) => _api.resetPasswordRequest(email);
 
   Future<void> resetPasswordConfirm(ResetPasswordConfirmRequest request) => _api.resetPasswordConfirm(request);
+
+  Future<void> deleteAccount({required String currentPassword, required bool agree}) async {
+    final token = await _tokenStorage.getAccessToken();
+    if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+    await _api.deleteAccount(token: token, currentPassword: currentPassword, agree: agree);
+  }
+
+  Future<StartEmailChangeResponse> startEmailChange({required String currentEmail, required String password}) async {
+    final token = await _tokenStorage.getAccessToken();
+    if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+    return _api.startEmailChange(
+      token: token,
+      request: StartEmailChangeRequest(currentEmail: currentEmail, password: password),
+    );
+  }
+
+  Future<void> sendEmailChangeCode({required String changeId, required String newEmail}) async {
+    final token = await _tokenStorage.getAccessToken();
+    if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+    await _api.sendEmailChangeCode(
+      token: token,
+      request: SendEmailChangeCodeRequest(changeId: changeId, newEmail: newEmail),
+    );
+  }
+
+  Future<VerifyEmailChangeResponse> verifyEmailChange({required String changeId, required String code}) async {
+    final token = await _tokenStorage.getAccessToken();
+    if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+    return _api.verifyEmailChange(
+      token: token,
+      request: VerifyEmailChangeRequest(changeId: changeId, code: code),
+    );
+  }
 }
 
 

--- a/lib/features/auth/screens/find_account_screen.dart
+++ b/lib/features/auth/screens/find_account_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../common/utils/external_link.dart';
 import '../viewmodels/find_account_view_model.dart';
 
 class FindAccountScreen extends StatefulWidget {
@@ -229,9 +230,12 @@ class _ResetPasswordForm extends StatelessWidget {
             onChanged: vm.setToken,
           ),
           const SizedBox(height: 8),
-          Text(
-            mailLinkText,
-            style: const TextStyle(fontSize: 12, color: Color(0xFF2563EB), decoration: TextDecoration.underline),
+          InkWell(
+            onTap: () => openExternalUrl(domain.isNotEmpty ? 'https://mail.$domain' : 'https://mail.sch.ac.kr'),
+            child: Text(
+              mailLinkText,
+              style: const TextStyle(fontSize: 12, color: Color(0xFF2563EB), decoration: TextDecoration.underline),
+            ),
           ),
         ],
         const SizedBox(height: 18),

--- a/lib/features/common/screens/placeholder_screen.dart
+++ b/lib/features/common/screens/placeholder_screen.dart
@@ -10,9 +10,18 @@ class PlaceholderScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(title)),
       body: Center(
-        child: Text(
-          '$title (임시 화면)',
-          style: const TextStyle(fontSize: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('$title (임시 화면)', style: const TextStyle(fontSize: 16)),
+            if (title == '/ (메인)') ...[
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pushNamed('/mypage'),
+                child: const Text('마이페이지로 이동(임시)'),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/lib/features/mypage/screens/change_email_screen.dart
+++ b/lib/features/mypage/screens/change_email_screen.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../viewmodels/change_email_view_model.dart';
+
+class ChangeEmailScreen extends StatefulWidget {
+  static const routeName = '/change-email';
+
+  const ChangeEmailScreen({super.key});
+
+  @override
+  State<ChangeEmailScreen> createState() => _ChangeEmailScreenState();
+}
+
+class _ChangeEmailScreenState extends State<ChangeEmailScreen> {
+  bool _loaded = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ChangeEmailViewModel>().load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<ChangeEmailViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('회원정보 변경'),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: 8),
+                const Text(
+                  '안전하게 이메일을 변경하기 위해서\n비밀번호를 한 번 더 입력해주세요',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 13, color: Color(0xFF6B7280), height: 1.35),
+                ),
+                const SizedBox(height: 22),
+                const Text('현재 이메일', style: TextStyle(fontSize: 12, color: Color(0xFF9CA3AF))),
+                const SizedBox(height: 6),
+                TextField(
+                  enabled: false,
+                  controller: TextEditingController(text: vm.currentEmail)
+                    ..selection = TextSelection.collapsed(offset: vm.currentEmail.length),
+                  decoration: const InputDecoration(
+                    border: UnderlineInputBorder(),
+                  ),
+                  style: const TextStyle(color: Color(0xFF9CA3AF)),
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        enabled: !vm.step1Done && !vm.loading,
+                        obscureText: true,
+                        decoration: const InputDecoration(
+                          hintText: '비밀번호',
+                          border: UnderlineInputBorder(),
+                        ),
+                        onChanged: vm.setPassword,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    SizedBox(
+                      height: 40,
+                      child: TextButton(
+                        onPressed: (!vm.step1Done && vm.password.isNotEmpty && !vm.loading) ? vm.verifyPassword : null,
+                        style: TextButton.styleFrom(
+                          backgroundColor: const Color(0xFFF97316),
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                        ).copyWith(
+                          backgroundColor: WidgetStateProperty.resolveWith((states) {
+                            if (states.contains(WidgetState.disabled)) return const Color(0xFFD1D5DB);
+                            return const Color(0xFFF97316);
+                          }),
+                        ),
+                        child: vm.step1Done
+                            ? const Text('완료', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700))
+                            : (vm.loading
+                                ? const SizedBox(
+                                    height: 16,
+                                    width: 16,
+                                    child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                                  )
+                                : const Text('확인', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700))),
+                      ),
+                    ),
+                  ],
+                ),
+                if (vm.step1Done) ...[
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          enabled: !vm.step2Done && !vm.loading,
+                          keyboardType: TextInputType.emailAddress,
+                          decoration: const InputDecoration(
+                            hintText: '새 이메일 (@sch.ac.kr)',
+                            border: UnderlineInputBorder(),
+                          ),
+                          onChanged: vm.setNewEmail,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      SizedBox(
+                        height: 40,
+                        child: TextButton(
+                          onPressed: (!vm.step2Done && vm.isValidNewEmail && !vm.loading) ? vm.sendCode : null,
+                          style: TextButton.styleFrom(
+                            backgroundColor: const Color(0xFFF97316),
+                            foregroundColor: Colors.white,
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                          ).copyWith(
+                            backgroundColor: WidgetStateProperty.resolveWith((states) {
+                              if (states.contains(WidgetState.disabled)) return const Color(0xFFD1D5DB);
+                              return const Color(0xFFF97316);
+                            }),
+                          ),
+                          child: vm.step2Done
+                              ? const Text('완료', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700))
+                              : (vm.loading
+                                  ? const SizedBox(
+                                      height: 16,
+                                      width: 16,
+                                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                                    )
+                                  : const Text('인증 요청', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700))),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+                if (vm.step2Done) ...[
+                  const SizedBox(height: 10),
+                  const Text(
+                    '메일함 열기 (mail.sch.ac.kr)',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Color(0xFF2563EB),
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextField(
+                          enabled: !vm.verified && !vm.loading,
+                          decoration: const InputDecoration(
+                            hintText: '인증 코드',
+                            border: UnderlineInputBorder(),
+                          ),
+                          onChanged: vm.setCode,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      SizedBox(
+                        height: 40,
+                        child: TextButton(
+                          onPressed: (!vm.verified && vm.code.isNotEmpty && !vm.loading) ? vm.verifyCode : null,
+                          style: TextButton.styleFrom(
+                            backgroundColor: const Color(0xFF22C55E),
+                            foregroundColor: Colors.white,
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                          ).copyWith(
+                            backgroundColor: WidgetStateProperty.resolveWith((states) {
+                              if (states.contains(WidgetState.disabled)) return const Color(0xFFD1D5DB);
+                              return const Color(0xFF22C55E);
+                            }),
+                          ),
+                          child: vm.verified
+                              ? const Text('완료', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700))
+                              : (vm.loading
+                                  ? const SizedBox(
+                                      height: 16,
+                                      width: 16,
+                                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                                    )
+                                  : const Text('확인', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700))),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+                if (vm.verified) ...[
+                  const SizedBox(height: 28),
+                  SizedBox(
+                    height: 50,
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFFF97316),
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                      ),
+                      onPressed: () async {
+                        final ok = await vm.finalizeAndRefreshMe();
+                        if (!context.mounted) return;
+                        if (ok) {
+                          Navigator.of(context).pushNamedAndRemoveUntil('/mypage', (r) => false);
+                        } else {
+                          await showDialog<void>(
+                            context: context,
+                            builder: (_) => AlertDialog(
+                              content: const Text(
+                                '이메일 변경은 성공했지만 정보 갱신에 실패했습니다.\n다시 로그인해주세요.',
+                                textAlign: TextAlign.center,
+                              ),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.of(context).pop(),
+                                  child: const Text('확인'),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (!context.mounted) return;
+                          Navigator.of(context).pushNamedAndRemoveUntil('/login', (r) => false);
+                        }
+                      },
+                      child: const Text('이메일 변경하기', style: TextStyle(fontSize: 16, fontWeight: FontWeight.w800)),
+                    ),
+                  ),
+                ],
+                if (vm.errMsg != null) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    vm.errMsg!,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/lib/features/mypage/screens/change_email_screen.dart
+++ b/lib/features/mypage/screens/change_email_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../common/utils/external_link.dart';
 import '../viewmodels/change_email_view_model.dart';
 
 class ChangeEmailScreen extends StatefulWidget {
@@ -151,12 +152,15 @@ class _ChangeEmailScreenState extends State<ChangeEmailScreen> {
                 ],
                 if (vm.step2Done) ...[
                   const SizedBox(height: 10),
-                  const Text(
-                    '메일함 열기 (mail.sch.ac.kr)',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Color(0xFF2563EB),
-                      decoration: TextDecoration.underline,
+                  InkWell(
+                    onTap: () => openExternalUrl('https://mail.sch.ac.kr'),
+                    child: const Text(
+                      '메일함 열기 (mail.sch.ac.kr)',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Color(0xFF2563EB),
+                        decoration: TextDecoration.underline,
+                      ),
                     ),
                   ),
                   const SizedBox(height: 18),

--- a/lib/features/mypage/screens/mypage_screen.dart
+++ b/lib/features/mypage/screens/mypage_screen.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auth/models/role.dart';
+import '../viewmodels/mypage_view_model.dart';
+
+class MyPageScreen extends StatefulWidget {
+  static const routeName = '/mypage';
+
+  const MyPageScreen({super.key});
+
+  @override
+  State<MyPageScreen> createState() => _MyPageScreenState();
+}
+
+class _MyPageScreenState extends State<MyPageScreen> {
+  bool _loaded = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await context.read<MyPageViewModel>().load();
+      if (!mounted) return;
+      final vm = context.read<MyPageViewModel>();
+      if (vm.shouldRelogin) {
+        await vm.logout();
+        if (!mounted) return;
+        Navigator.of(context).pushNamedAndRemoveUntil('/login', (r) => false);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<MyPageViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('마이페이지'),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: vm.loading && vm.me == null
+          ? const Center(child: CircularProgressIndicator())
+          : _Body(vm: vm),
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  final MyPageViewModel vm;
+  const _Body({required this.vm});
+
+  @override
+  Widget build(BuildContext context) {
+    final me = vm.me;
+
+    if (me == null) {
+      return Center(
+        child: Text(vm.errorMessage ?? '불러오기에 실패했습니다.'),
+      );
+    }
+
+    final isStudent = me.role == Role.student;
+    final badgeBg = isStudent ? const Color(0xFFFFEDD5) : const Color(0xFFDBEAFE);
+    final badgeFg = isStudent ? const Color(0xFFEA580C) : const Color(0xFF2563EB);
+    final badgeText = isStudent ? '학생' : '관리자';
+
+    return Container(
+      color: const Color(0xFFF3F4F6),
+      child: Column(
+        children: [
+          Container(
+            color: Colors.white,
+            padding: const EdgeInsets.only(bottom: 20),
+            child: Container(
+              margin: const EdgeInsets.only(left: 16, right: 16, top: 8),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(14),
+                boxShadow: const [
+                  BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4)),
+                ],
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 56,
+                    height: 56,
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFE5E7EB),
+                      borderRadius: BorderRadius.circular(28),
+                    ),
+                    child: const Icon(Icons.person, color: Color(0xFF9CA3AF), size: 30),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          me.username,
+                          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          me.email,
+                          style: const TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                    decoration: BoxDecoration(color: badgeBg, borderRadius: BorderRadius.circular(999)),
+                    child: Text(badgeText, style: TextStyle(fontSize: 12, color: badgeFg, fontWeight: FontWeight.w700)),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Container(
+            color: Colors.white,
+            child: Column(
+              children: [
+                _MenuItem(
+                  label: '회원정보 수정',
+                  onTap: () => Navigator.of(context).pushNamed('/change-email'),
+                ),
+                const Divider(height: 1, color: Color(0xFFE5E7EB)),
+                _MenuItem(
+                  label: '비밀번호 변경',
+                  onTap: () => Navigator.of(context).pushNamed('/find-account', arguments: 'pw'),
+                ),
+                const Divider(height: 1, color: Color(0xFFE5E7EB)),
+                _MenuItem(
+                  label: '로그아웃',
+                  onTap: () async {
+                    await vm.logout();
+                    if (!context.mounted) return;
+                    Navigator.of(context).pushNamedAndRemoveUntil('/login', (r) => false);
+                  },
+                ),
+                const Divider(height: 1, color: Color(0xFFE5E7EB)),
+                _MenuItem(
+                  label: '회원탈퇴',
+                  labelColor: const Color(0xFFEF4444),
+                  onTap: () async {
+                    final ok = await showDialog<bool>(
+                      context: context,
+                      builder: (_) => const _DeleteAccountDialog(),
+                    );
+                    if (ok != true) return;
+                    final success = await vm.deleteAccount();
+                    if (!context.mounted) return;
+                    if (success) {
+                      Navigator.of(context).pushNamedAndRemoveUntil('/login', (r) => false);
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(vm.errorMessage ?? '회원 탈퇴에 실패했습니다. 다시 시도해주세요.')),
+                      );
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuItem extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final Color? labelColor;
+  const _MenuItem({required this.label, required this.onTap, this.labelColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        child: Text(
+          label,
+          style: TextStyle(fontSize: 14, color: labelColor ?? const Color(0xFF374151)),
+        ),
+      ),
+    );
+  }
+}
+
+class _DeleteAccountDialog extends StatelessWidget {
+  const _DeleteAccountDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: const Text(
+        '탈퇴하면 모든 기록이 사라집니다\n정말 탈퇴하시겠습니까?',
+        textAlign: TextAlign.center,
+        style: TextStyle(height: 1.4),
+      ),
+      actionsPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      actions: [
+        Row(
+          children: [
+            Expanded(
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                style: TextButton.styleFrom(
+                  backgroundColor: const Color(0xFFFEF2F2),
+                  foregroundColor: const Color(0xFFEF4444),
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+                ),
+                child: const Text('탈퇴하기', style: TextStyle(fontWeight: FontWeight.w700)),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                style: TextButton.styleFrom(
+                  backgroundColor: const Color(0xFF737373),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+                ),
+                child: const Text('취소', style: TextStyle(fontWeight: FontWeight.w700)),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+

--- a/lib/features/mypage/viewmodels/change_email_view_model.dart
+++ b/lib/features/mypage/viewmodels/change_email_view_model.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../common/dio/api_exception.dart';
+import '../../../common/dio/api_error_mapper.dart';
+import '../../auth/repositories/auth_repository.dart';
+
+class ChangeEmailViewModel extends ChangeNotifier {
+  ChangeEmailViewModel(this._repo);
+
+  final AuthRepository _repo;
+
+  bool loading = false;
+  String? errMsg;
+
+  String currentEmail = '';
+  String password = '';
+  String newEmail = '';
+  String code = '';
+
+  String? changeId;
+
+  bool step1Done = false;
+  bool step2Done = false;
+  bool verified = false;
+
+  Future<void> load() async {
+    errMsg = null;
+    notifyListeners();
+    try {
+      final me = await _repo.getMe();
+      currentEmail = me.email;
+      notifyListeners();
+    } catch (e) {
+      if (e is ApiException) {
+        errMsg = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errMsg = '불러오기에 실패했습니다.';
+      }
+      notifyListeners();
+    }
+  }
+
+  void setPassword(String v) {
+    password = v;
+    notifyListeners();
+  }
+
+  void setNewEmail(String v) {
+    newEmail = v;
+    notifyListeners();
+  }
+
+  void setCode(String v) {
+    code = v;
+    notifyListeners();
+  }
+
+  bool get isValidNewEmail => newEmail.trim().endsWith('@sch.ac.kr');
+
+  Future<void> verifyPassword() async {
+    if (loading) return;
+    loading = true;
+    errMsg = null;
+    notifyListeners();
+    try {
+      final res = await _repo.startEmailChange(currentEmail: currentEmail, password: password);
+      changeId = res.changeId;
+      step1Done = true;
+    } catch (e) {
+      if (e is ApiException) {
+        errMsg = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errMsg = '비밀번호 확인 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> sendCode() async {
+    if (loading) return;
+    if (changeId == null) return;
+
+    if (!isValidNewEmail) {
+      errMsg = '이메일은 반드시 @sch.ac.kr 형식이어야 합니다.';
+      notifyListeners();
+      return;
+    }
+
+    loading = true;
+    errMsg = null;
+    notifyListeners();
+    try {
+      await _repo.sendEmailChangeCode(changeId: changeId!, newEmail: newEmail.trim());
+      step2Done = true;
+    } catch (e) {
+      if (e is ApiException) {
+        errMsg = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errMsg = '인증 요청 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> verifyCode() async {
+    if (loading) return;
+    if (changeId == null) return;
+
+    loading = true;
+    errMsg = null;
+    notifyListeners();
+    try {
+      await _repo.verifyEmailChange(changeId: changeId!, code: code.trim());
+      verified = true;
+    } catch (e) {
+      if (e is ApiException) {
+        errMsg = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errMsg = '코드 검증 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  /// true면 /mypage로 이동, false면 /login 유도(웹과 동일)
+  Future<bool> finalizeAndRefreshMe() async {
+    try {
+      await _repo.getMe();
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+}
+
+

--- a/lib/features/mypage/viewmodels/mypage_view_model.dart
+++ b/lib/features/mypage/viewmodels/mypage_view_model.dart
@@ -40,6 +40,12 @@ class MyPageViewModel extends ChangeNotifier {
   }
 
   Future<void> logout() async {
+    // 로그아웃 직후에도 "이전 me 캐시"가 남아있으면
+    // 다음 진입에서 마이페이지가 잠깐 보였다가 튕기는 UX가 발생할 수 있어 즉시 초기화.
+    me = null;
+    errorMessage = null;
+    shouldRelogin = false;
+    notifyListeners();
     await _repo.logout();
   }
 

--- a/lib/features/mypage/viewmodels/mypage_view_model.dart
+++ b/lib/features/mypage/viewmodels/mypage_view_model.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+
+import '../../auth/repositories/auth_repository.dart';
+import '../../users/models/me_response.dart';
+import '../../../common/dio/api_exception.dart';
+import '../../../common/dio/api_error_mapper.dart';
+
+class MyPageViewModel extends ChangeNotifier {
+  MyPageViewModel(this._repo);
+
+  final AuthRepository _repo;
+
+  MeResponse? me;
+  bool loading = false;
+  String? errorMessage;
+  bool shouldRelogin = false;
+
+  Future<void> load() async {
+    loading = true;
+    errorMessage = null;
+    shouldRelogin = false;
+    notifyListeners();
+
+    try {
+      me = await _repo.getMe();
+    } catch (e) {
+      if (e is ApiException) {
+        // 토큰 만료/미보유 등은 로그인으로 유도
+        if (e.statusCode == 401 || e.message.contains('로그인이 필요')) {
+          shouldRelogin = true;
+        }
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '불러오기에 실패했습니다.';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> logout() async {
+    await _repo.logout();
+  }
+
+  Future<bool> deleteAccount() async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      await _repo.deleteAccount(currentPassword: '', agree: true);
+      await _repo.logout();
+      return true;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '회원 탈퇴에 실패했습니다. 다시 시도해주세요.';
+      }
+      return false;
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+}
+
+

--- a/lib/features/signup/screens/signup_credentials_screen.dart
+++ b/lib/features/signup/screens/signup_credentials_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../common/utils/external_link.dart';
 import '../../auth/viewmodels/signup_view_model.dart';
 import 'signup_terms_screen.dart';
 
@@ -389,10 +390,7 @@ class _InputEmail extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           InkWell(
-            onTap: () {
-              // iOS/Android에서 기본 브라우저로 열기(간단히 시스템 처리)
-              // 실제로는 url_launcher를 쓰는 게 정석이지만, 현재 의존성 추가 없이 UI만 먼저 맞춤.
-            },
+            onTap: () => openExternalUrl('https://mail.sch.ac.kr'),
             child: const Text(
               '메일함 열기 (mail.sch.ac.kr)',
               style: TextStyle(fontSize: 12, color: Color(0xFF2563EB), decoration: TextDecoration.underline),

--- a/lib/features/users/models/me_response.dart
+++ b/lib/features/users/models/me_response.dart
@@ -1,12 +1,33 @@
 import '../../auth/models/role.dart';
 
 class MeResponse {
+  final int? accountId;
   final Role role;
+  final String username;
+  final String email;
+  final int? storeId;
+  final String? storeName;
 
-  MeResponse({required this.role});
+  MeResponse({
+    this.accountId,
+    required this.role,
+    required this.username,
+    required this.email,
+    this.storeId,
+    this.storeName,
+  });
 
   factory MeResponse.fromJson(Map<String, dynamic> json) {
-    return MeResponse(role: RoleApi.fromApi((json['role'] ?? 'STUDENT').toString()));
+    int? toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString());
+
+    return MeResponse(
+      accountId: toInt(json['accountId']),
+      role: RoleApi.fromApi((json['role'] ?? 'STUDENT').toString()),
+      username: (json['username'] ?? '').toString(),
+      email: (json['email'] ?? '').toString(),
+      storeId: toInt(json['storeId']),
+      storeName: json['storeName']?.toString(),
+    );
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,10 @@ import 'features/auth/viewmodels/find_account_view_model.dart';
 import 'features/auth/viewmodels/login_view_model.dart';
 import 'features/auth/viewmodels/signup_view_model.dart';
 import 'features/common/screens/placeholder_screen.dart';
+import 'features/mypage/screens/change_email_screen.dart';
+import 'features/mypage/screens/mypage_screen.dart';
+import 'features/mypage/viewmodels/change_email_view_model.dart';
+import 'features/mypage/viewmodels/mypage_view_model.dart';
 import 'features/signup/screens/signup_credentials_screen.dart';
 import 'features/signup/screens/signup_id_screen.dart';
 import 'features/signup/screens/signup_terms_screen.dart';
@@ -39,6 +43,8 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => LoginViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => SignupViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => FindAccountViewModel(authRepo)),
+        ChangeNotifierProvider(create: (_) => MyPageViewModel(authRepo)),
+        ChangeNotifierProvider(create: (_) => ChangeEmailViewModel(authRepo)),
       ],
       child: MaterialApp(
         title: '1000meal App',
@@ -49,6 +55,8 @@ class MyApp extends StatelessWidget {
           LoginScreen.routeName: (_) => const LoginScreen(),
           '/': (_) => const PlaceholderScreen(title: '/ (메인)'),
           '/admin': (_) => const PlaceholderScreen(title: '/admin'),
+          MyPageScreen.routeName: (_) => const MyPageScreen(),
+          ChangeEmailScreen.routeName: (_) => const ChangeEmailScreen(),
           // signup
           '/signup': (_) => const SignupIdScreen(),
           SignupIdScreen.routeName: (_) => const SignupIdScreen(),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,11 +8,13 @@ import Foundation
 import flutter_secure_storage_darwin
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   intl: ^0.20.2
   shared_preferences: ^2.5.4
   webview_flutter: ^4.13.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## 연결 이슈
- Closes #6

---

## 배경(Why)
- 기존 웹(Next.js)에서 제공하던 **마이페이지** 및 **회원정보 수정(이메일 변경 3단계)** 플로우를 Flutter 앱으로 마이그래이션합니다.
- Flutter 앱 아키텍처는 **MVVM** 기반이며 상태 관리는 **provider(ChangeNotifier)** 로 통일합니다.
- 인증 토큰은 **flutter_secure_storage**에 저장된 값을 사용하고, API 통신은 **dio** 기반으로 구성합니다(공통 에러 매핑 포함).

---

## 목표(What)
- 웹과 동일한 UX/검증/에러 처리 수준으로 마이페이지 및 이메일 변경 기능을 Flutter로 이식합니다.
- iOS/Android(시뮬레이터/에뮬레이터 기준)에서 끝까지 정상 동작하도록 합니다.

---

## 구현 내용(요약)
### 1) 마이페이지
- 진입 시 사용자 정보 로드(`GET /auth/me`)
  - token 없음/401 시 자동 로그아웃 처리 후 로그인 화면 유도
- 프로필 카드(이름/이메일/role badge) + 메뉴 구성
  - 회원정보 수정 → `/change-email`
  - 비밀번호 변경 → `/find-account`(pw 탭)
  - 로그아웃 → 토큰 삭제 후 `/login`
  - 회원탈퇴 → 확인 모달 → 탈퇴 API 호출 성공 시 로그아웃 처리

### 2) 회원정보 수정(이메일 변경) — 3단계(로그인 필요)
- Step1: 비밀번호 확인 → `POST /account/email/start` (changeId 획득)
- Step2: 새 이메일 입력(@sch.ac.kr 제한) + 코드 발송 → `POST /account/email/code`
- Step3: 코드 검증 → `POST /account/email/verify`
- 최종 처리
  - `getMe`로 갱신 시도 성공 시 `/mypage`
  - 실패 시 “갱신 실패, 재로그인 필요” 안내 후 `/login`

### 3) UX 개선(인증/리다이렉트)
- 비로그인 상태에서 마이페이지로 진입할 때 “잠깐 마이페이지가 보였다가 로그인으로 튕김” 현상을 줄이기 위해:
  - 메인(임시) 마이페이지 버튼에서 사전 `getMe()` 검증 후 이동
  - `/mypage` 진입 시에도 토큰 선체크 및 로그아웃 시 VM 캐시 초기화

### 4) 메일함 링크 동작
- “메일함 열기(mail.sch.ac.kr)” 링크를 `url_launcher`로 외부 브라우저에서 열리도록 처리
  - 회원가입/계정찾기/이메일변경 화면에 적용

---

## API 엔드포인트(백엔드 계약)
- 내 정보: `GET /auth/me`
- 회원탈퇴(로그인 필요): `POST /auth/delete-account`
- 이메일 변경(로그인 필요):
  - `POST /account/email/start`
  - `POST /account/email/code`
  - `POST /account/email/verify`

---

## 라우팅
- `/mypage`
- `/change-email`
- (기존 연동) `/find-account` (pw 탭 arguments로 이동)

---

## 수동 테스트(체크리스트)
- [ ] 로그인 상태에서 `/mypage` 진입 → 프로필 카드/role badge 표시 확인
- [ ] 토큰 없음/401에서 `/mypage` 진입 시 `/login` 유도 확인(UX 확인 포함)
- [ ] 로그아웃 동작(토큰 삭제 후 `/login` 이동)
- [ ] 회원탈퇴 모달 → 탈퇴 성공 시 세션 초기화 및 `/login` 이동
- [ ] 이메일 변경 3단계
  - [ ] Step1 비밀번호 실패/성공
  - [ ] Step2 새 이메일 `@sch.ac.kr` 제한 동작
  - [ ] Step3 코드 실패/성공
  - [ ] 최종 갱신 성공 시 `/mypage`, 실패 시 안내 후 `/login`
- [ ] `메일함 열기 (mail.sch.ac.kr)` 외부 브라우저 오픈 확인
- [ ] `flutter analyze` 통과