### PR TITLE
[FEAT] 관리자 페이지 1차 마이그레이션: /admin 대시보드 진입/가드/네비

### DIFF
--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auth/repositories/auth_repository.dart';
+import '../viewmodels/admin_home_view_model.dart';
+
+class AdminHomeScreen extends StatefulWidget {
+  static const routeName = '/admin';
+
+  const AdminHomeScreen({super.key});
+
+  @override
+  State<AdminHomeScreen> createState() => _AdminHomeScreenState();
+}
+
+class _AdminHomeScreenState extends State<AdminHomeScreen> {
+  bool _loaded = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminHomeViewModel>().load());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<AdminHomeViewModel>();
+
+    final name = vm.me?.username.isNotEmpty == true ? vm.me!.username : '가게명 불러오는 중...';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(''),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/', (r) => false),
+        ),
+        actions: [
+          IconButton(
+            onPressed: () => _showToast(context, '준비중입니다'),
+            icon: const Icon(Icons.settings),
+          ),
+        ],
+      ),
+      body: Container(
+        color: const Color(0xFFF3F4F6),
+        child: ListView(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+          children: [
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(color: const Color(0xFFD1D5DB), borderRadius: BorderRadius.circular(24)),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(name, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                    decoration: BoxDecoration(color: const Color(0xFFDBEAFE), borderRadius: BorderRadius.circular(999)),
+                    child: const Text('관리자', style: TextStyle(fontSize: 12, color: Color(0xFF2563EB), fontWeight: FontWeight.w700)),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 14),
+            Row(
+              children: [
+                Expanded(
+                  child: _SquareCard(
+                    title: '영업 중',
+                    subtitle: '준비중',
+                    highlight: true,
+                    onTap: () => _showToast(context, '준비중입니다'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _SquareCard(
+                    title: '재고 관리',
+                    subtitle: '',
+                    onTap: () => _showToast(context, '다음 이슈에서 구현 예정'),
+                    trailing: const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 28),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            _WideCard(
+              title: '메뉴 관리',
+              onTap: () => _showToast(context, '다음 이슈에서 구현 예정'),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 48,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFEF4444),
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                ),
+                onPressed: () async {
+                  await context.read<AuthRepository>().logout();
+                  if (!context.mounted) return;
+                  Navigator.of(context).pushNamedAndRemoveUntil('/login', (r) => false);
+                },
+                child: const Text('로그아웃', style: TextStyle(fontWeight: FontWeight.w700)),
+              ),
+            ),
+            if (vm.loading) ...[
+              const SizedBox(height: 12),
+              const Center(child: CircularProgressIndicator()),
+            ],
+            if (vm.errorMessage != null) ...[
+              const SizedBox(height: 12),
+              Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  static void _showToast(BuildContext context, String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg), duration: const Duration(milliseconds: 900)));
+  }
+}
+
+class _SquareCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool highlight;
+  final VoidCallback onTap;
+  final Widget? trailing;
+
+  const _SquareCard({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    this.highlight = false,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = highlight ? const Color(0xFF93C5FD) : Colors.white;
+    final fg = highlight ? Colors.white : const Color(0xFF111827);
+    final subFg = highlight ? const Color(0xFFEFF6FF) : const Color(0xFF9CA3AF);
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        height: 160,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+        ),
+        child: Stack(
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: TextStyle(fontSize: 18, fontWeight: FontWeight.w800, color: fg)),
+                if (subtitle.isNotEmpty) ...[
+                  const SizedBox(height: 6),
+                  Text(subtitle, style: TextStyle(fontSize: 12, color: subFg)),
+                ],
+              ],
+            ),
+            Positioned(bottom: 6, right: 6, child: trailing ?? const SizedBox.shrink()),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WideCard extends StatelessWidget {
+  final String title;
+  final VoidCallback onTap;
+
+  const _WideCard({required this.title, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+        ),
+        child: Row(
+          children: [
+            Expanded(child: Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800))),
+            const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 28),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+

--- a/lib/features/admin/viewmodels/admin_home_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_home_view_model.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+
+import '../../auth/repositories/auth_repository.dart';
+import '../../users/models/me_response.dart';
+
+class AdminHomeViewModel extends ChangeNotifier {
+  AdminHomeViewModel(this._repo);
+
+  final AuthRepository _repo;
+
+  bool loading = false;
+  String? errorMessage;
+  MeResponse? me;
+
+  Future<void> load() async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      me = await _repo.getMe();
+    } catch (_) {
+      errorMessage = '불러오기에 실패했습니다.';
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+}
+
+

--- a/lib/features/common/screens/placeholder_screen.dart
+++ b/lib/features/common/screens/placeholder_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../auth/repositories/auth_repository.dart';
+import '../../auth/models/role.dart';
 import 'package:provider/provider.dart';
 
 class PlaceholderScreen extends StatelessWidget {
@@ -32,9 +33,9 @@ class PlaceholderScreen extends StatelessWidget {
                   // 만료/무효 토큰일 때 `/mypage` -> `/login`으로 튕기며 깜빡임이 생김.
                   // 사전 검증(getMe)로 성공일 때만 마이페이지로 이동.
                   try {
-                    await repo.getMe();
+                    final me = await repo.getMe();
                     if (!context.mounted) return;
-                    Navigator.of(context).pushNamed('/mypage');
+                    Navigator.of(context).pushNamed(me.role == Role.admin ? '/admin' : '/mypage');
                   } catch (_) {
                     await repo.logout();
                     if (!context.mounted) return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => FindAccountViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => MyPageViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => ChangeEmailViewModel(authRepo)),
+<<<<<<< HEAD
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo)),
       ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,7 +61,6 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => FindAccountViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => MyPageViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => ChangeEmailViewModel(authRepo)),
-<<<<<<< HEAD
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo)),
       ],


### PR DESCRIPTION
## 배경(Why)
- 기존 웹(Next.js)의 관리자 대시보드 진입 흐름을 모바일(Flutter)로 1차 이식하고, 보호 라우트 접근/로그아웃 UX를 안정화한다.

## 목표(What)
- ADMIN은 `/admin` 진입 가능
- STUDENT가 `/admin` 접근 시 역할에 맞는 화면으로 리다이렉트

## 변경사항(What changed)
- **Admin 1차 화면**
  - `AdminHomeScreen` 추가: 관리자 대시보드(카드 UI + 메뉴/재고 진입 버튼(Coming soon))
  - `AdminHomeViewModel` 추가: 관리자 정보 로딩 및 에러 표시
- **라우팅/가드**
  - `RoleGuard` 추가: 토큰 유무 + role 검증 후 `/admin`, `/mypage`, `/login`로 안전하게 라우팅
  - `main.dart` 리베이스 충돌 해결 및 라우트 정리
    - `/` → `MainScreen` (학생 로그인 성공 시 기본 진입)
    - `/admin` → `RoleGuard(Role.admin) + AdminHomeScreen`
    - `/mypage` → `RoleGuard(Role.student) + MyPageScreen`
- **메인 프로필 버튼 역할 분기**
  - `HomePage` 프로필 버튼에서 token/getMe 사전 검증 후 role 기반 이동
    - token 없음 → `/login`
    - STUDENT → `/mypage`
    - ADMIN → `/admin`

## 참고(관련 코드)
- `lib/features/auth/screens/role_guard.dart`
- `lib/features/admin/screens/admin_home_screen.dart`
- `lib/features/admin/viewmodels/admin_home_view_model.dart`
- `lib/widgets/HomePage.dart`
- `lib/features/mypage/screens/mypage_screen.dart`
- `lib/features/auth/repositories/auth_repository.dart`
- `lib/main.dart`

## 테스트(How to test)
- [ ] 학생 계정 로그인 → `/` 진입 → 프로필 버튼 → `/mypage` 이동 확인
- [ ] 관리자 계정 로그인 → `/admin` 진입 확인
- [ ] 토큰 없음 상태에서 보호 라우트(`/mypage`, `/admin`) 접근 → `/login` 이동 확인
- [ ] 학생 계정 로그인 후 로그아웃 → 즉시 `/login` 이동 및 무한로딩(스피너 고정) 미발생 확인
- [ ] 역할 불일치 접근(학생이 `/admin`, 관리자가 `/mypage`) → 역할에 맞는 화면으로 리다이렉트 확인

## 체크리스트
- [ ] 기능 단위로 검증 완료
- [ ] iOS/Android에서 동작 확인

## 이슈
- Closes #8