### PR TITLE
[FEAT] Admin: 영업 상태 토글 + 재고관리(/admin/inventory) API 연동

### DIFF
--- a/lib/common/utils/jwt_payload.dart
+++ b/lib/common/utils/jwt_payload.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+class JwtPayload {
+  final String? sub;
+  final String? role;
+  final int? storeId;
+  final int? exp;
+
+  const JwtPayload({
+    required this.sub,
+    required this.role,
+    required this.storeId,
+    required this.exp,
+  });
+
+  factory JwtPayload.fromJson(Map<String, dynamic> json) {
+    int? asInt(dynamic v) => v is int ? v : int.tryParse(v?.toString() ?? '');
+
+    return JwtPayload(
+      sub: json['sub']?.toString(),
+      role: json['role']?.toString(),
+      storeId: asInt(json['storeId']),
+      exp: asInt(json['exp']),
+    );
+  }
+}
+
+/// Decodes JWT payload without verifying signature.
+///
+/// Returns null when token is malformed or payload isn't JSON.
+JwtPayload? decodeJwtPayload(String token) {
+  final parts = token.split('.');
+  if (parts.length < 2) return null;
+
+  final payload = parts[1];
+  try {
+    final normalized = base64Url.normalize(payload);
+    final bytes = base64Url.decode(normalized);
+    final map = json.decode(utf8.decode(bytes));
+    if (map is Map<String, dynamic>) return JwtPayload.fromJson(map);
+    return null;
+  } catch (_) {
+    return null;
+  }
+}
+
+int? getStoreIdFromToken(String? token) => token == null ? null : decodeJwtPayload(token)?.storeId;
+

--- a/lib/common/utils/kst_date.dart
+++ b/lib/common/utils/kst_date.dart
@@ -1,0 +1,9 @@
+String kstTodayYmd() {
+  final nowUtc = DateTime.now().toUtc();
+  final kst = nowUtc.add(const Duration(hours: 9));
+  final y = kst.year.toString().padLeft(4, '0');
+  final m = kst.month.toString().padLeft(2, '0');
+  final d = kst.day.toString().padLeft(2, '0');
+  return '$y-$m-$d';
+}
+

--- a/lib/features/admin/data/admin_api.dart
+++ b/lib/features/admin/data/admin_api.dart
@@ -1,0 +1,55 @@
+import '../../../common/dio/dio_client.dart';
+
+import '../models/menu_models.dart';
+import '../models/store_models.dart';
+
+class AdminApi {
+  final DioClient _client;
+  AdminApi(this._client);
+
+  Map<String, dynamic> _unwrapData(Map<String, dynamic> root) {
+    final inner = root['data'];
+    if (inner is Map<String, dynamic>) return inner;
+    return root;
+  }
+
+  Future<StoreDetail> getStoreDetail({required int storeId, required String token}) async {
+    final root = await _client.get<Map<String, dynamic>>(
+      '/stores/$storeId',
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    return StoreDetail.fromJson(_unwrapData(root));
+  }
+
+  Future<void> toggleStoreStatus({required int storeId, required String token}) async {
+    await _client.post<Object>(
+      '/stores/status/$storeId',
+      headers: {'Authorization': 'Bearer $token'},
+    );
+  }
+
+  Future<DailyMenuResponse?> getDailyMenu({required int storeId, required String date, required String token}) async {
+    final root = await _client.get<Map<String, dynamic>>(
+      '/menus/daily/$storeId',
+      queryParameters: {'date': date},
+      headers: {'Authorization': 'Bearer $token'},
+    );
+
+    final data = root['data'];
+    if (data == null) return null;
+    if (data is Map<String, dynamic>) return DailyMenuResponse.fromJson(data);
+
+    final unwrapped = _unwrapData(root);
+    if (unwrapped.isEmpty) return null;
+    return DailyMenuResponse.fromJson(unwrapped);
+  }
+
+  Future<void> updateDailyStock({required int menuId, required int stock, required String token}) async {
+    await _client.post<Object>(
+      '/menus/daily/stock/$menuId',
+      headers: {'Authorization': 'Bearer $token'},
+      data: {'stock': stock},
+    );
+  }
+}
+

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -13,12 +13,19 @@ class DailyMenuResponse {
 
   factory DailyMenuResponse.fromJson(Map<String, dynamic> json) {
     int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    bool toBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is num) return v != 0;
+      final s = v?.toString().trim().toLowerCase();
+      if (s == null || s.isEmpty) return false;
+      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+    }
 
     return DailyMenuResponse(
       id: toInt(json['id']),
       date: (json['date'] ?? '').toString(),
       stock: toInt(json['stock'] ?? 0),
-      open: json['open'] == true || (json['open']?.toString().toLowerCase() == 'true'),
+      open: toBool(json['open']),
     );
   }
 }

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -1,0 +1,25 @@
+class DailyMenuResponse {
+  final int id;
+  final String date; // YYYY-MM-DD
+  final int stock;
+  final bool open;
+
+  DailyMenuResponse({
+    required this.id,
+    required this.date,
+    required this.stock,
+    required this.open,
+  });
+
+  factory DailyMenuResponse.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+
+    return DailyMenuResponse(
+      id: toInt(json['id']),
+      date: (json['date'] ?? '').toString(),
+      stock: toInt(json['stock'] ?? 0),
+      open: json['open'] == true || (json['open']?.toString().toLowerCase() == 'true'),
+    );
+  }
+}
+

--- a/lib/features/admin/models/store_models.dart
+++ b/lib/features/admin/models/store_models.dart
@@ -1,0 +1,18 @@
+class StoreDetail {
+  final int id;
+  final String name;
+  final bool open;
+
+  StoreDetail({required this.id, required this.name, required this.open});
+
+  factory StoreDetail.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+
+    return StoreDetail(
+      id: toInt(json['id']),
+      name: (json['name'] ?? '').toString(),
+      open: json['open'] == true || (json['open']?.toString().toLowerCase() == 'true'),
+    );
+  }
+}
+

--- a/lib/features/admin/models/store_models.dart
+++ b/lib/features/admin/models/store_models.dart
@@ -7,11 +7,18 @@ class StoreDetail {
 
   factory StoreDetail.fromJson(Map<String, dynamic> json) {
     int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    bool toBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is num) return v != 0;
+      final s = v?.toString().trim().toLowerCase();
+      if (s == null || s.isEmpty) return false;
+      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+    }
 
     return StoreDetail(
       id: toInt(json['id']),
       name: (json['name'] ?? '').toString(),
-      open: json['open'] == true || (json['open']?.toString().toLowerCase() == 'true'),
+      open: toBool(json['open']),
     );
   }
 }

--- a/lib/features/admin/repositories/admin_repository.dart
+++ b/lib/features/admin/repositories/admin_repository.dart
@@ -1,0 +1,58 @@
+import '../../../common/dio/api_exception.dart';
+import '../../../common/utils/jwt_payload.dart';
+import '../../auth/repositories/auth_repository.dart';
+import '../../users/models/me_response.dart';
+import '../data/admin_api.dart';
+import '../models/menu_models.dart';
+import '../models/store_models.dart';
+
+class AdminRepository {
+  final AuthRepository _authRepo;
+  final AdminApi _api;
+
+  AdminRepository({required AuthRepository authRepo, required AdminApi api})
+      : _authRepo = authRepo,
+        _api = api;
+
+  Future<String> _requireToken() async {
+    final token = await _authRepo.getAccessToken();
+    if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+    return token;
+  }
+
+  Future<int> _requireStoreId(String token) async {
+    final fromToken = getStoreIdFromToken(token);
+    if (fromToken != null) return fromToken;
+
+    // fallback: /auth/me
+    final me = await _authRepo.getMe();
+    if (me.storeId == null) throw ApiException('가게 정보가 없습니다.');
+    return me.storeId!;
+  }
+
+  Future<MeResponse> getMe() => _authRepo.getMe();
+
+  Future<StoreDetail> getStoreDetail() async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    return _api.getStoreDetail(storeId: storeId, token: token);
+  }
+
+  Future<void> toggleStoreStatus() async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    await _api.toggleStoreStatus(storeId: storeId, token: token);
+  }
+
+  Future<DailyMenuResponse?> getDailyMenu({required String date}) async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    return _api.getDailyMenu(storeId: storeId, date: date, token: token);
+  }
+
+  Future<void> updateDailyStock({required int menuId, required int stock}) async {
+    final token = await _requireToken();
+    await _api.updateDailyStock(menuId: menuId, stock: stock, token: token);
+  }
+}
+

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -93,7 +93,12 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
                   child: _SquareCard(
                     title: '재고 관리',
                     subtitle: '',
-                    onTap: () => Navigator.of(context).pushNamed('/admin/inventory'),
+                    onTap: () {
+                      Navigator.of(context).pushNamed('/admin/inventory').then((_) {
+                        if (!context.mounted) return;
+                        context.read<AdminHomeViewModel>().load();
+                      });
+                    },
                     trailing: const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 28),
                   ),
                 ),
@@ -183,8 +188,7 @@ class _OpenStatusCard extends StatelessWidget {
                 const SizedBox(height: 6),
                 if (loading)
                   Text('처리 중...', style: TextStyle(fontSize: 12, color: fg))
-                else
-                  Text(isOpen ? '영업 상태 변경 가능' : '현재 영업 전', style: TextStyle(fontSize: 12, color: fg)),
+                
               ],
             ),
             Positioned(

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:provider/provider.dart';
 
 import '../../auth/repositories/auth_repository.dart';
@@ -28,7 +29,9 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
   Widget build(BuildContext context) {
     final vm = context.watch<AdminHomeViewModel>();
 
-    final name = vm.me?.username.isNotEmpty == true ? vm.me!.username : '가게명 불러오는 중...';
+    final storeName = vm.store?.name.isNotEmpty == true
+        ? vm.store!.name
+        : (vm.me?.storeName?.isNotEmpty == true ? vm.me!.storeName! : '가게명 불러오는 중...');
 
     return Scaffold(
       appBar: AppBar(
@@ -65,7 +68,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
                   ),
                   const SizedBox(width: 12),
                   Expanded(
-                    child: Text(name, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
+                    child: Text(storeName, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
                   ),
                   Container(
                     padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
@@ -79,11 +82,10 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
             Row(
               children: [
                 Expanded(
-                  child: _SquareCard(
-                    title: '영업 중',
-                    subtitle: '준비중',
-                    highlight: true,
-                    onTap: () => _showToast(context, '준비중입니다'),
+                  child: _OpenStatusCard(
+                    isOpen: vm.isOpen,
+                    loading: vm.loading || vm.toggling,
+                    onToggle: vm.toggling ? null : () => vm.toggleOpen(),
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -91,7 +93,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
                   child: _SquareCard(
                     title: '재고 관리',
                     subtitle: '',
-                    onTap: () => _showToast(context, '다음 이슈에서 구현 예정'),
+                    onTap: () => Navigator.of(context).pushNamed('/admin/inventory'),
                     trailing: const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 28),
                   ),
                 ),
@@ -112,9 +114,9 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                 ),
                 onPressed: () async {
-                  await context.read<AuthRepository>().logout();
-                  if (!context.mounted) return;
                   Navigator.of(context).pushNamedAndRemoveUntil('/login', (r) => false);
+                  // best-effort logout (do not block UI / navigation)
+                  unawaited(context.read<AuthRepository>().logout());
                 },
                 child: const Text('로그아웃', style: TextStyle(fontWeight: FontWeight.w700)),
               ),
@@ -138,10 +140,87 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
   }
 }
 
+class _OpenStatusCard extends StatelessWidget {
+  final bool isOpen;
+  final bool loading;
+  final VoidCallback? onToggle;
+
+  const _OpenStatusCard({
+    required this.isOpen,
+    required this.loading,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = isOpen ? const Color(0xFF93C5FD) : Colors.white;
+    final fg = isOpen ? Colors.white : const Color(0xFF9CA3AF);
+    final toggleTrack = isOpen ? Colors.white : const Color(0xFFD1D5DB);
+    final toggleThumb = isOpen ? const Color(0xFF93C5FD) : Colors.white;
+
+    return InkWell(
+      onTap: loading ? null : onToggle,
+      borderRadius: BorderRadius.circular(16),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+        height: 160,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+        ),
+        child: Stack(
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  isOpen ? '영업 중' : '영업 종료',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.w800, color: isOpen ? Colors.white : const Color(0xFF6B7280)),
+                ),
+                const SizedBox(height: 6),
+                if (loading)
+                  Text('처리 중...', style: TextStyle(fontSize: 12, color: fg))
+                else
+                  Text(isOpen ? '영업 상태 변경 가능' : '현재 영업 전', style: TextStyle(fontSize: 12, color: fg)),
+              ],
+            ),
+            Positioned(
+              bottom: 10,
+              right: 10,
+              child: IgnorePointer(
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 250),
+                  curve: Curves.easeInOut,
+                  width: 64,
+                  height: 36,
+                  decoration: BoxDecoration(color: toggleTrack, borderRadius: BorderRadius.circular(999)),
+                  child: AnimatedAlign(
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                    alignment: isOpen ? Alignment.centerRight : Alignment.centerLeft,
+                    child: Container(
+                      width: 28,
+                      height: 28,
+                      margin: const EdgeInsets.symmetric(horizontal: 6),
+                      decoration: BoxDecoration(color: toggleThumb, borderRadius: BorderRadius.circular(999)),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _SquareCard extends StatelessWidget {
   final String title;
   final String subtitle;
-  final bool highlight;
   final VoidCallback onTap;
   final Widget? trailing;
 
@@ -149,15 +228,14 @@ class _SquareCard extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.onTap,
-    this.highlight = false,
     this.trailing,
   });
 
   @override
   Widget build(BuildContext context) {
-    final bg = highlight ? const Color(0xFF93C5FD) : Colors.white;
-    final fg = highlight ? Colors.white : const Color(0xFF111827);
-    final subFg = highlight ? const Color(0xFFEFF6FF) : const Color(0xFF9CA3AF);
+    final bg = Colors.white;
+    final fg = const Color(0xFF111827);
+    final subFg = const Color(0xFF9CA3AF);
 
     return InkWell(
       onTap: onTap,

--- a/lib/features/admin/screens/admin_inventory_screen.dart
+++ b/lib/features/admin/screens/admin_inventory_screen.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../viewmodels/admin_inventory_view_model.dart';
+
+class AdminInventoryScreen extends StatefulWidget {
+  static const routeName = '/admin/inventory';
+
+  const AdminInventoryScreen({super.key});
+
+  @override
+  State<AdminInventoryScreen> createState() => _AdminInventoryScreenState();
+}
+
+class _AdminInventoryScreenState extends State<AdminInventoryScreen> {
+  final _controller = TextEditingController();
+  bool _loaded = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminInventoryViewModel>().loadToday());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<AdminInventoryViewModel>();
+    _controller.value = _controller.value.copyWith(text: vm.stock.toString(), selection: TextSelection.collapsed(offset: vm.stock.toString().length));
+
+    final formatted = _formatKstKorean(vm.date);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(''),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: Stack(
+        children: [
+          Container(
+            color: const Color(0xFFFAFAFA),
+            child: ListView(
+              padding: EdgeInsets.zero,
+              children: [
+                // 날짜 바
+                Container(
+                  color: Colors.white,
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  child: RichText(
+                    text: TextSpan(
+                      style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: Color(0xFF6B7280)),
+                      children: [
+                        TextSpan(text: '${formatted.monthDay} '),
+                        TextSpan(text: formatted.weekday, style: const TextStyle(color: Color(0xFFFB923C))),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // 재고 패널
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 18, 16, 16),
+                  child: Column(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(16),
+                          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '현재 수량',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.w700,
+                                color: vm.open ? const Color(0xFF111827) : const Color(0xFFD1D5DB),
+                              ),
+                            ),
+                            Row(
+                              children: [
+                                _CircleButton(
+                                  label: '–',
+                                  onTap: () => vm.adjustStock(-1),
+                                  disabled: vm.loading || vm.saving,
+                                ),
+                                const SizedBox(width: 10),
+                                SizedBox(
+                                  width: 96,
+                                  height: 48,
+                                  child: TextField(
+                                    controller: _controller,
+                                    enabled: !vm.loading && !vm.saving,
+                                    keyboardType: TextInputType.number,
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.w700,
+                                      color: vm.open ? const Color(0xFF111827) : const Color(0xFFD1D5DB),
+                                    ),
+                                    decoration: InputDecoration(
+                                      contentPadding: EdgeInsets.zero,
+                                      border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+                                    ),
+                                    onChanged: vm.setStockFromInput,
+                                    onSubmitted: (_) => vm.commitStock(),
+                                    onEditingComplete: () => vm.commitStock(),
+                                  ),
+                                ),
+                                const SizedBox(width: 10),
+                                _CircleButton(
+                                  label: '+',
+                                  onTap: () => vm.adjustStock(1),
+                                  disabled: vm.loading || vm.saving,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      Container(
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(16),
+                          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+                        ),
+                        child: Row(
+                          children: const [10, 5, 1].asMap().entries.map((e) {
+                            final idx = e.key;
+                            final value = e.value;
+                            return Expanded(
+                              child: _QuickMinusButton(value: value, showDivider: idx < 2),
+                            );
+                          }).toList(growable: false),
+                        ),
+                      ),
+                      if (vm.errorMessage != null) ...[
+                        const SizedBox(height: 12),
+                        Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
+                      ],
+                      if (vm.loading) ...[
+                        const SizedBox(height: 14),
+                        const Center(child: CircularProgressIndicator()),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // 영업 전 모달
+          if (vm.showOpenModal)
+            Positioned.fill(
+              child: Container(
+                color: Colors.black.withValues(alpha: 0.3),
+                child: Center(
+                  child: Container(
+                    width: 280,
+                    padding: const EdgeInsets.all(18),
+                    decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16)),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text('아직 영업 전입니다', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+                        const SizedBox(height: 6),
+                        const Text(
+                          '영업중으로 상태를 변경하시겠습니까?',
+                          style: TextStyle(fontSize: 13, color: Color(0xFF6B7280)),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 14),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextButton(
+                                onPressed: vm.saving ? null : vm.closeModal,
+                                style: TextButton.styleFrom(
+                                  backgroundColor: const Color(0xFFF3F4F6),
+                                  foregroundColor: const Color(0xFF6B7280),
+                                  padding: const EdgeInsets.symmetric(vertical: 12),
+                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                ),
+                                child: const Text('아니요'),
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: TextButton(
+                                onPressed: vm.saving ? null : vm.confirmOpenAndUnlock,
+                                style: TextButton.styleFrom(
+                                  backgroundColor: const Color(0xFF60A5FA),
+                                  foregroundColor: Colors.white,
+                                  padding: const EdgeInsets.symmetric(vertical: 12),
+                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                ),
+                                child: vm.saving
+                                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                                    : const Text('네'),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+          // 재고 0개 → 영업 종료 제안 모달
+          if (vm.showCloseModal)
+            Positioned.fill(
+              child: Container(
+                color: Colors.black.withValues(alpha: 0.3),
+                child: Center(
+                  child: Container(
+                    width: 280,
+                    padding: const EdgeInsets.all(18),
+                    decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(16)),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text('재고가 0개입니다', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+                        const SizedBox(height: 6),
+                        const Text(
+                          '영업 종료로 상태를 변경하시겠습니까?',
+                          style: TextStyle(fontSize: 13, color: Color(0xFF6B7280)),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 14),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextButton(
+                                onPressed: vm.saving ? null : vm.closeModal,
+                                style: TextButton.styleFrom(
+                                  backgroundColor: const Color(0xFFF3F4F6),
+                                  foregroundColor: const Color(0xFF6B7280),
+                                  padding: const EdgeInsets.symmetric(vertical: 12),
+                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                ),
+                                child: const Text('아니요'),
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: TextButton(
+                                onPressed: vm.saving ? null : vm.confirmCloseAndLock,
+                                style: TextButton.styleFrom(
+                                  backgroundColor: const Color(0xFF60A5FA),
+                                  foregroundColor: Colors.white,
+                                  padding: const EdgeInsets.symmetric(vertical: 12),
+                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                ),
+                                child: vm.saving
+                                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                                    : const Text('네'),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CircleButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+  final bool disabled;
+  const _CircleButton({required this.label, required this.onTap, required this.disabled});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: disabled ? null : onTap,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: const Color(0xFFD1D5DB),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Center(
+          child: Text(label, style: const TextStyle(color: Colors.white, fontSize: 18, height: 1.0)),
+        ),
+      ),
+    );
+  }
+}
+
+class _QuickMinusButton extends StatelessWidget {
+  final int value;
+  final bool showDivider;
+  const _QuickMinusButton({required this.value, required this.showDivider});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.read<AdminInventoryViewModel>();
+    return InkWell(
+      onTap: () => vm.adjustStock(-value),
+      child: Container(
+        height: 112,
+        decoration: BoxDecoration(
+          border: showDivider ? const Border(right: BorderSide(color: Color(0xFFE5E7EB))) : null,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 20,
+              height: 20,
+              decoration: BoxDecoration(color: const Color(0xFFD1D5DB), borderRadius: BorderRadius.circular(999)),
+              child: const Center(child: Text('–', style: TextStyle(color: Colors.white, fontSize: 14, height: 1.0))),
+            ),
+            const SizedBox(width: 8),
+            Text('$value개', style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _KstKoreanDate {
+  final String monthDay; // "1월 19일"
+  final String weekday; // "월요일"
+  const _KstKoreanDate({required this.monthDay, required this.weekday});
+}
+
+_KstKoreanDate _formatKstKorean(String ymd) {
+  // ymd: YYYY-MM-DD
+  final parts = ymd.split('-');
+  final y = int.tryParse(parts.elementAtOrNull(0) ?? '') ?? 2000;
+  final m = int.tryParse(parts.elementAtOrNull(1) ?? '') ?? 1;
+  final d = int.tryParse(parts.elementAtOrNull(2) ?? '') ?? 1;
+  final dt = DateTime(y, m, d);
+  const weekdays = ['월요일', '화요일', '수요일', '목요일', '금요일', '토요일', '일요일'];
+  final wd = weekdays[(dt.weekday - 1).clamp(0, 6)];
+  return _KstKoreanDate(monthDay: '$m월 $d일', weekday: wd);
+}
+
+extension _ListExt<T> on List<T> {
+  T? elementAtOrNull(int index) => (index >= 0 && index < length) ? this[index] : null;
+}
+

--- a/lib/features/admin/viewmodels/admin_home_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_home_view_model.dart
@@ -2,15 +2,23 @@ import 'package:flutter/foundation.dart';
 
 import '../../auth/repositories/auth_repository.dart';
 import '../../users/models/me_response.dart';
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../data/admin_api.dart';
+import '../models/store_models.dart';
 
 class AdminHomeViewModel extends ChangeNotifier {
-  AdminHomeViewModel(this._repo);
+  AdminHomeViewModel(this._repo, this._adminApi);
 
   final AuthRepository _repo;
+  final AdminApi _adminApi;
 
   bool loading = false;
   String? errorMessage;
   MeResponse? me;
+  StoreDetail? store;
+  bool isOpen = false;
+  bool toggling = false;
 
   Future<void> load() async {
     loading = true;
@@ -18,10 +26,53 @@ class AdminHomeViewModel extends ChangeNotifier {
     notifyListeners();
     try {
       me = await _repo.getMe();
-    } catch (_) {
-      errorMessage = '불러오기에 실패했습니다.';
+      final token = await _repo.getAccessToken();
+      final storeId = me?.storeId;
+      if (token == null || token.isEmpty) throw ApiException('로그인이 필요합니다.');
+      if (storeId == null) throw ApiException('가게 정보가 없습니다.');
+
+      store = await _adminApi.getStoreDetail(storeId: storeId, token: token);
+      isOpen = store?.open ?? false;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '불러오기에 실패했습니다.';
+      }
     } finally {
       loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggleOpen() async {
+    if (toggling) return;
+    final token = await _repo.getAccessToken();
+    final storeId = me?.storeId;
+    if (token == null || token.isEmpty || storeId == null) {
+      errorMessage = '로그인이 필요합니다.';
+      notifyListeners();
+      return;
+    }
+
+    toggling = true;
+    errorMessage = null;
+    final prev = isOpen;
+    isOpen = !isOpen; // optimistic
+    notifyListeners();
+
+    try {
+      await _adminApi.toggleStoreStatus(storeId: storeId, token: token);
+    } catch (e) {
+      // rollback
+      isOpen = prev;
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '영업 상태 변경에 실패했습니다.';
+      }
+    } finally {
+      toggling = false;
       notifyListeners();
     }
   }

--- a/lib/features/admin/viewmodels/admin_inventory_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_inventory_view_model.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../../../common/utils/kst_date.dart';
+import '../models/menu_models.dart';
+import '../repositories/admin_repository.dart';
+
+class AdminInventoryViewModel extends ChangeNotifier {
+  AdminInventoryViewModel(this._repo);
+
+  final AdminRepository _repo;
+
+  bool loading = false;
+  bool saving = false;
+  String? errorMessage;
+
+  String date = kstTodayYmd(); // YYYY-MM-DD (KST fixed)
+
+  DailyMenuResponse? daily;
+  int stock = 0;
+  bool open = false;
+
+  bool showOpenModal = false;
+  bool showCloseModal = false;
+  int _lastSavedStock = 0;
+
+  Future<void> loadToday() async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+
+    try {
+      final res = await _repo.getDailyMenu(date: date);
+      daily = res;
+      stock = res?.stock ?? 0;
+      open = res?.open ?? false;
+      _lastSavedStock = stock;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '오늘 재고 불러오기 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  void closeModal() {
+    showOpenModal = false;
+    showCloseModal = false;
+    notifyListeners();
+  }
+
+  Future<void> confirmOpenAndUnlock() async {
+    // modal confirm: 실제 영업 토글 API 호출 (요구사항)
+    saving = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      await _repo.toggleStoreStatus();
+      open = true;
+      showOpenModal = false;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '영업 상태 변경에 실패했습니다.';
+      }
+    } finally {
+      saving = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> confirmCloseAndLock() async {
+    // modal confirm: 실제 영업 토글 API 호출 (요구사항)
+    saving = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      await _repo.toggleStoreStatus();
+      open = false;
+      showCloseModal = false;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '영업 상태 변경에 실패했습니다.';
+      }
+    } finally {
+      saving = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> adjustStock(int delta) async {
+    if (!open) {
+      showOpenModal = true;
+      notifyListeners();
+      return;
+    }
+    final next = (stock + delta).clamp(0, 1 << 30);
+    stock = next;
+    notifyListeners();
+    await commitStock();
+  }
+
+  void setStockFromInput(String raw) {
+    final parsed = int.tryParse(raw.trim()) ?? 0;
+    stock = parsed < 0 ? 0 : parsed;
+    notifyListeners();
+  }
+
+  Future<void> commitStock() async {
+    if (!open) return;
+    final menuId = daily?.id;
+    if (menuId == null) return;
+
+    saving = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      await _repo.updateDailyStock(menuId: menuId, stock: stock);
+      // 영업 중 상태에서 재고가 0으로 떨어졌을 때, 영업 종료 전환 모달 제안
+      if (open && stock == 0 && _lastSavedStock > 0) {
+        showCloseModal = true;
+      }
+      _lastSavedStock = stock;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '재고 업데이트 실패';
+      }
+    } finally {
+      saving = false;
+      notifyListeners();
+    }
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,8 +15,11 @@ import 'features/auth/viewmodels/find_account_view_model.dart';
 import 'features/auth/viewmodels/login_view_model.dart';
 import 'features/auth/viewmodels/signup_view_model.dart';
 import 'features/admin/data/admin_api.dart';
+import 'features/admin/repositories/admin_repository.dart';
 import 'features/admin/screens/admin_home_screen.dart';
+import 'features/admin/screens/admin_inventory_screen.dart';
 import 'features/admin/viewmodels/admin_home_view_model.dart';
+import 'features/admin/viewmodels/admin_inventory_view_model.dart';
 import 'features/auth/models/role.dart';
 import 'features/mypage/screens/change_email_screen.dart';
 import 'features/mypage/screens/mypage_screen.dart';
@@ -54,11 +57,13 @@ class MyApp extends StatelessWidget {
     final authApi = AuthApi(dioClient);
     final adminApi = AdminApi(dioClient);
     final authRepo = AuthRepository(api: authApi, tokenStorage: tokenStorage);
+    final adminRepo = AdminRepository(authRepo: authRepo, api: adminApi);
 
     return MultiProvider(
       providers: [
         Provider.value(value: authRepo),
         Provider.value(value: adminApi),
+        Provider.value(value: adminRepo),
         ChangeNotifierProvider(create: (_) => LoginViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => SignupViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => FindAccountViewModel(authRepo)),
@@ -66,6 +71,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => ChangeEmailViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo, adminApi)),
+        ChangeNotifierProvider(create: (_) => AdminInventoryViewModel(adminRepo)),
       ],
       child: MaterialApp(
         title: '1000meal App',
@@ -82,6 +88,10 @@ class MyApp extends StatelessWidget {
           AdminHomeScreen.routeName: (_) => const RoleGuard(
                 targetRole: Role.admin,
                 child: AdminHomeScreen(),
+              ),
+          AdminInventoryScreen.routeName: (_) => const RoleGuard(
+                targetRole: Role.admin,
+                child: AdminInventoryScreen(),
               ),
           MyPageScreen.routeName: (_) => const RoleGuard(
                 targetRole: Role.student,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'features/auth/screens/role_guard.dart';
 import 'features/auth/viewmodels/find_account_view_model.dart';
 import 'features/auth/viewmodels/login_view_model.dart';
 import 'features/auth/viewmodels/signup_view_model.dart';
+import 'features/admin/data/admin_api.dart';
 import 'features/admin/screens/admin_home_screen.dart';
 import 'features/admin/viewmodels/admin_home_view_model.dart';
 import 'features/auth/models/role.dart';
@@ -51,18 +52,20 @@ class MyApp extends StatelessWidget {
     final tokenStorage = TokenStorage();
     final dioClient = DioClient.create();
     final authApi = AuthApi(dioClient);
+    final adminApi = AdminApi(dioClient);
     final authRepo = AuthRepository(api: authApi, tokenStorage: tokenStorage);
 
     return MultiProvider(
       providers: [
         Provider.value(value: authRepo),
+        Provider.value(value: adminApi),
         ChangeNotifierProvider(create: (_) => LoginViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => SignupViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => FindAccountViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => MyPageViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => ChangeEmailViewModel(authRepo)),
         ChangeNotifierProvider(create: (_) => AuthProvider()),
-        ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo)),
+        ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo, adminApi)),
       ],
       child: MaterialApp(
         title: '1000meal App',

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,24 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:meal_app/common/config/app_config.dart';
 import 'package:meal_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    // AppConfig(apiBaseUrl)에서 dotenv를 읽기 때문에, 테스트 시작 전에 로드.
+    await AppConfig.load();
+  });
+
+  testWidgets('App boots to LoginScreen', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // 로그인 화면의 버튼 텍스트(로그인)가 보여야 한다.
+    expect(find.text('로그인'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 배경(Why)
- 웹(Next.js)의 관리자 기능(영업중/영업종료 토글, 재고관리)을 모바일(Flutter)로 이식한다.
- MVVM + provider(ChangeNotifier) + dio + flutter_secure_storage 기준으로 구현한다.

## 목표(What)
- `/admin`에서 영업 상태 토글이 API와 연동되어 동작
- `/admin/inventory`에서 KST 기준 오늘 재고 조회/수정이 API와 연동되어 동작
- 재고/영업 상태 변경 후 화면 전환 시 상태가 즉시 일관되게 반영

## 변경사항(What changed)
### 1) 관리자 영업 상태 토글
- `/admin` 영업중/영업종료 토글 UI 구현
- `POST /stores/status/{storeId}` 연동(optimistic UI + 실패 시 롤백)
- `GET /stores/{storeId}`로 상태 로드
- 재고관리에서 돌아올 때 `/admin`이 `load()` 재호출하여 상태 즉시 반영

### 2) 재고관리(/admin/inventory)
- KST(Asia/Seoul) 기준 `YYYY-MM-DD`로 오늘 날짜 생성 후 조회
- `GET /menus/daily/{storeId}?date=...`로 오늘 메뉴/재고 조회(오늘 메뉴 없음(null)도 정상 처리)
- `POST /menus/daily/stock/{menuId}`로 재고 업데이트
- open=false(영업 종료) 상태에서 재고 조작 시 모달 → ‘네’ 선택 시 영업 토글 API 호출로 실제 영업중 전환 후 조작 가능
- open=true(영업 중) 상태에서 재고가 0이 되는 순간 모달 → ‘네’ 선택 시 영업 종료로 토글 API 호출

### 3) 공통/구조
- 토큰에서 storeId 추출용 JWT payload 디코드 유틸 추가(+ /auth/me fallback)
- open 값 파싱 보강(bool/0·1/"1" 등 다양한 형태 대응)
- Admin 전용 API/Repository/VM 추가(재고/영업 상태 로직 분리)

### 4) 라우팅/가드
- `/admin/inventory` 라우트 추가
- `RoleGuard(Role.admin)`로 보호
- `/admin`에서 재고관리로 네비 연결

### 5) 테스트
- 기본 템플릿 widget_test를 현재 앱 구조에 맞춘 “LoginScreen 부팅 스모크 테스트”로 교체
- `flutter test` 통과 확인

## 참고 파일
- `lib/features/admin/screens/admin_home_screen.dart`
- `lib/features/admin/screens/admin_inventory_screen.dart`
- `lib/features/admin/viewmodels/admin_home_view_model.dart`
- `lib/features/admin/viewmodels/admin_inventory_view_model.dart`
- `lib/features/admin/data/admin_api.dart`
- `lib/features/admin/repositories/admin_repository.dart`
- `lib/common/utils/jwt_payload.dart`
- `lib/common/utils/kst_date.dart`
- `lib/main.dart`
- `test/widget_test.dart`

## 테스트(How to test)
- [ ] ADMIN 로그인 → `/admin` 진입 → 영업 토글 ON/OFF API 반영 확인
- [ ] `/admin/inventory` 진입 → 오늘 재고 조회 확인
- [ ] 재고 +/-/직접입력/빠른감소(10/5/1) → 재고 업데이트 API 호출 확인
- [ ] open=false에서 조작 → 모달 → ‘네’ → 영업중 전환 후 조작 가능 확인
- [ ] open=true에서 재고 0 도달 → 모달 → ‘네’ → 영업종료 전환 확인
- [ ] 재고/영업 상태 변경 후 back으로 `/admin` 복귀 시 즉시 반영 확인

## 이슈
- Closes #10