### PR TITLE
[FEAT] Admin 메뉴관리 마이그레이션: 주간 메뉴 리스트/메뉴 편집/자주 쓰는 메뉴

### DIFF
--- a/lib/common/dio/dio_client.dart
+++ b/lib/common/dio/dio_client.dart
@@ -76,6 +76,52 @@ class DioClient {
       );
     }
   }
+
+  Future<T> put<T>(
+    String path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    try {
+      final res = await _dio.put<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: Options(headers: headers),
+      );
+      return res.data as T;
+    } on DioException catch (e) {
+      throw ApiException(
+        e.message ?? '네트워크 오류가 발생했습니다.',
+        statusCode: e.response?.statusCode,
+        details: e.response?.data,
+      );
+    }
+  }
+
+  Future<T> delete<T>(
+    String path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    try {
+      final res = await _dio.delete<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: Options(headers: headers),
+      );
+      return res.data as T;
+    } on DioException catch (e) {
+      throw ApiException(
+        e.message ?? '네트워크 오류가 발생했습니다.',
+        statusCode: e.response?.statusCode,
+        details: e.response?.data,
+      );
+    }
+  }
 }
 
 

--- a/lib/common/utils/week_kst.dart
+++ b/lib/common/utils/week_kst.dart
@@ -1,0 +1,28 @@
+DateTime _parseYmd(String ymd) {
+  final parts = ymd.split('-');
+  final y = int.parse(parts[0]);
+  final m = int.parse(parts[1]);
+  final d = int.parse(parts[2]);
+  return DateTime(y, m, d);
+}
+
+String _fmtYmd(DateTime dt) {
+  final y = dt.year.toString().padLeft(4, '0');
+  final m = dt.month.toString().padLeft(2, '0');
+  final d = dt.day.toString().padLeft(2, '0');
+  return '$y-$m-$d';
+}
+
+/// Returns monday(YYYY-MM-DD) of the week that includes [ymd] (KST date string).
+String mondayOfYmd(String ymd) {
+  final dt = _parseYmd(ymd);
+  // DateTime.weekday: 1(Mon) .. 7(Sun)
+  final diff = dt.weekday - DateTime.monday;
+  final monday = dt.subtract(Duration(days: diff));
+  return _fmtYmd(monday);
+}
+
+String addDaysYmd(String ymd, int days) => _fmtYmd(_parseYmd(ymd).add(Duration(days: days)));
+
+String addWeeksYmd(String ymd, int weeks) => addDaysYmd(ymd, weeks * 7);
+

--- a/lib/features/admin/data/admin_api.dart
+++ b/lib/features/admin/data/admin_api.dart
@@ -76,5 +76,46 @@ class AdminApi {
     );
     return DailyMenuResponse.fromJson(_unwrapData(root));
   }
+
+  // 자주 쓰는 메뉴 API
+  Future<FavoritesResponse> getFavorites({required int storeId, required String token}) async {
+    final root = await _client.get<Map<String, dynamic>>(
+      '/favorites/store/$storeId',
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    return FavoritesResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<FavoritesResponse> getFavoriteGroup({required int groupId, required String token}) async {
+    final root = await _client.get<Map<String, dynamic>>(
+      '/favorites/group/$groupId',
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    return FavoritesResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<void> createFavorite({required int storeId, required List<String> menus, required String token}) async {
+    await _client.post<Object>(
+      '/favorites/$storeId',
+      headers: {'Authorization': 'Bearer $token'},
+      data: menus,
+    );
+  }
+
+  Future<void> updateFavorite({required int groupId, required List<String> menus, required String token}) async {
+    await _client.put<Object>(
+      '/favorites/$groupId',
+      headers: {'Authorization': 'Bearer $token'},
+      data: menus,
+    );
+  }
+
+  Future<void> deleteFavorites({required int storeId, required List<int> groupIds, required String token}) async {
+    await _client.delete<Object>(
+      '/favorites/$storeId/groups',
+      headers: {'Authorization': 'Bearer $token'},
+      data: groupIds,
+    );
+  }
 }
 

--- a/lib/features/admin/data/admin_api.dart
+++ b/lib/features/admin/data/admin_api.dart
@@ -51,5 +51,30 @@ class AdminApi {
       data: {'stock': stock},
     );
   }
+
+  Future<WeeklyMenuResponse> getWeeklyMenu({required int storeId, required String date, required String token}) async {
+    final root = await _client.get<Map<String, dynamic>>(
+      '/menus/weekly/$storeId',
+      queryParameters: {'date': date},
+      headers: {'Authorization': 'Bearer $token'},
+    );
+
+    final unwrapped = _unwrapData(root);
+    return WeeklyMenuResponse.fromJson(unwrapped);
+  }
+
+  Future<DailyMenuResponse> saveDailyMenu({
+    required int storeId,
+    required String date,
+    required List<String> menus,
+    required String token,
+  }) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/menus/daily/$storeId',
+      headers: {'Authorization': 'Bearer $token'},
+      data: {'date': date, 'menus': menus},
+    );
+    return DailyMenuResponse.fromJson(_unwrapData(root));
+  }
 }
 

--- a/lib/features/admin/models/admin_menu_week.dart
+++ b/lib/features/admin/models/admin_menu_week.dart
@@ -1,0 +1,18 @@
+class AdminMenuDay {
+  final String id; // YYYY-MM-DD
+  final String dateLabel; // MM.DD
+  final String weekdayLabel; // 월/화/...
+  final List<String> items;
+  final bool isPast;
+  final bool isToday;
+
+  AdminMenuDay({
+    required this.id,
+    required this.dateLabel,
+    required this.weekdayLabel,
+    required this.items,
+    required this.isPast,
+    required this.isToday,
+  });
+}
+

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -30,3 +30,71 @@ class DailyMenuResponse {
   }
 }
 
+class WeeklyMenuDay {
+  final int id;
+  final String date; // YYYY-MM-DD
+  final int? stock;
+  final List<String> menus;
+  final bool open;
+
+  WeeklyMenuDay({
+    required this.id,
+    required this.date,
+    required this.stock,
+    required this.menus,
+    required this.open,
+  });
+
+  factory WeeklyMenuDay.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    int? toIntNullable(dynamic v) => v == null ? null : (v is int ? v : int.tryParse(v.toString()));
+    bool toBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is num) return v != 0;
+      final s = v?.toString().trim().toLowerCase();
+      if (s == null || s.isEmpty) return false;
+      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+    }
+
+    final rawMenus = json['menus'];
+    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+
+    return WeeklyMenuDay(
+      id: toInt(json['id']),
+      date: (json['date'] ?? '').toString(),
+      stock: toIntNullable(json['stock']),
+      menus: menus,
+      open: toBool(json['open']),
+    );
+  }
+}
+
+class WeeklyMenuResponse {
+  final int storeId;
+  final String startDate;
+  final String endDate;
+  final List<WeeklyMenuDay> dailyMenus;
+
+  WeeklyMenuResponse({
+    required this.storeId,
+    required this.startDate,
+    required this.endDate,
+    required this.dailyMenus,
+  });
+
+  factory WeeklyMenuResponse.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    final list = json['dailyMenus'];
+    final daily = list is List
+        ? list.whereType<Map>().map((e) => WeeklyMenuDay.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <WeeklyMenuDay>[];
+
+    return WeeklyMenuResponse(
+      storeId: toInt(json['storeId']),
+      startDate: (json['startDate'] ?? '').toString(),
+      endDate: (json['endDate'] ?? '').toString(),
+      dailyMenus: daily,
+    );
+  }
+}
+

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -1,18 +1,23 @@
 class DailyMenuResponse {
   final int id;
   final String date; // YYYY-MM-DD
-  final int stock;
+  final String dayOfWeek; // MONDAY, TUESDAY ...
+  final int? stock;
+  final List<String> menus;
   final bool open;
 
   DailyMenuResponse({
     required this.id,
     required this.date,
+    required this.dayOfWeek,
     required this.stock,
+    required this.menus,
     required this.open,
   });
 
   factory DailyMenuResponse.fromJson(Map<String, dynamic> json) {
     int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    int? toIntNullable(dynamic v) => v == null ? null : (v is int ? v : int.tryParse(v.toString()));
     bool toBool(dynamic v) {
       if (v is bool) return v;
       if (v is num) return v != 0;
@@ -21,10 +26,15 @@ class DailyMenuResponse {
       return s == 'true' || s == '1' || s == 'y' || s == 'yes';
     }
 
+    final rawMenus = json['menus'];
+    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+
     return DailyMenuResponse(
       id: toInt(json['id']),
       date: (json['date'] ?? '').toString(),
-      stock: toInt(json['stock'] ?? 0),
+      dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
+      stock: toIntNullable(json['stock']),
+      menus: menus,
       open: toBool(json['open']),
     );
   }
@@ -33,6 +43,7 @@ class DailyMenuResponse {
 class WeeklyMenuDay {
   final int id;
   final String date; // YYYY-MM-DD
+  final String dayOfWeek; // 월, 화, ... or MONDAY...
   final int? stock;
   final List<String> menus;
   final bool open;
@@ -40,6 +51,7 @@ class WeeklyMenuDay {
   WeeklyMenuDay({
     required this.id,
     required this.date,
+    required this.dayOfWeek,
     required this.stock,
     required this.menus,
     required this.open,
@@ -62,6 +74,7 @@ class WeeklyMenuDay {
     return WeeklyMenuDay(
       id: toInt(json['id']),
       date: (json['date'] ?? '').toString(),
+      dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
       stock: toIntNullable(json['stock']),
       menus: menus,
       open: toBool(json['open']),

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -111,3 +111,38 @@ class WeeklyMenuResponse {
   }
 }
 
+class FavoriteGroup {
+  final int groupId;
+  final List<String> menu;
+
+  FavoriteGroup({
+    required this.groupId,
+    required this.menu,
+  });
+
+  factory FavoriteGroup.fromJson(Map<String, dynamic> json) {
+    final rawMenus = json['menu'];
+    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+
+    return FavoriteGroup(
+      groupId: json['groupId'] as int,
+      menu: menus,
+    );
+  }
+}
+
+class FavoritesResponse {
+  final List<FavoriteGroup> groups;
+
+  FavoritesResponse({required this.groups});
+
+  factory FavoritesResponse.fromJson(Map<String, dynamic> json) {
+    final list = json['groups'];
+    final groups = list is List
+        ? list.whereType<Map>().map((e) => FavoriteGroup.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <FavoriteGroup>[];
+
+    return FavoritesResponse(groups: groups);
+  }
+}
+

--- a/lib/features/admin/repositories/admin_repository.dart
+++ b/lib/features/admin/repositories/admin_repository.dart
@@ -66,5 +66,34 @@ class AdminRepository {
     final storeId = await _requireStoreId(token);
     return _api.saveDailyMenu(storeId: storeId, date: date, menus: menus, token: token);
   }
+
+  // 자주 쓰는 메뉴 API
+  Future<FavoritesResponse> getFavorites() async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    return _api.getFavorites(storeId: storeId, token: token);
+  }
+
+  Future<FavoritesResponse> getFavoriteGroup({required int groupId}) async {
+    final token = await _requireToken();
+    return _api.getFavoriteGroup(groupId: groupId, token: token);
+  }
+
+  Future<void> createFavorite({required List<String> menus}) async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    await _api.createFavorite(storeId: storeId, menus: menus, token: token);
+  }
+
+  Future<void> updateFavorite({required int groupId, required List<String> menus}) async {
+    final token = await _requireToken();
+    await _api.updateFavorite(groupId: groupId, menus: menus, token: token);
+  }
+
+  Future<void> deleteFavorites({required List<int> groupIds}) async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    await _api.deleteFavorites(storeId: storeId, groupIds: groupIds, token: token);
+  }
 }
 

--- a/lib/features/admin/repositories/admin_repository.dart
+++ b/lib/features/admin/repositories/admin_repository.dart
@@ -54,5 +54,17 @@ class AdminRepository {
     final token = await _requireToken();
     await _api.updateDailyStock(menuId: menuId, stock: stock, token: token);
   }
+
+  Future<WeeklyMenuResponse> getWeeklyMenu({required String date}) async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    return _api.getWeeklyMenu(storeId: storeId, date: date, token: token);
+  }
+
+  Future<DailyMenuResponse> saveDailyMenu({required String date, required List<String> menus}) async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    return _api.saveDailyMenu(storeId: storeId, date: date, menus: menus, token: token);
+  }
 }
 

--- a/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
@@ -1,0 +1,316 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../viewmodels/admin_frequent_menu_edit_view_model.dart';
+
+class AdminFrequentMenuEditScreen extends StatefulWidget {
+  static const routeName = '/admin/menu/frequent/edit';
+
+  final int? groupId; // null이면 새로 만들기, 있으면 수정
+
+  const AdminFrequentMenuEditScreen({super.key, this.groupId});
+
+  @override
+  State<AdminFrequentMenuEditScreen> createState() => _AdminFrequentMenuEditScreenState();
+}
+
+class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScreen> {
+  bool _loaded = false;
+  Timer? _toastTimer;
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _toastTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminFrequentMenuEditViewModel>().init());
+  }
+
+  Future<bool> _confirmDiscardIfDirty(AdminFrequentMenuEditViewModel vm) async {
+    if (!vm.dirty) return true;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('변경사항이 있어요'),
+        content: const Text('저장하지 않고 나갈까요?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(false), child: const Text('취소')),
+          TextButton(onPressed: () => Navigator.of(context).pop(true), child: const Text('나가기')),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<AdminFrequentMenuEditViewModel>();
+
+    if (_controller.text != vm.input) {
+      _controller.value = TextEditingValue(
+        text: vm.input,
+        selection: TextSelection.collapsed(offset: vm.input.length),
+      );
+    }
+
+    // toast (저장되었습니다)
+    if (vm.showSavedToast) {
+      _toastTimer?.cancel();
+      _toastTimer = Timer(const Duration(milliseconds: 700), () {
+        if (!mounted) return;
+        context.read<AdminFrequentMenuEditViewModel>().hideToast();
+      });
+    }
+
+    // 확인 모달
+    if (vm.showConfirm && vm.pendingAction != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showDialog(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('변경사항이 있어요'),
+            content: const Text('저장하지 않고 나갈까요?'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  context.read<AdminFrequentMenuEditViewModel>().setShowConfirm(false);
+                  context.read<AdminFrequentMenuEditViewModel>().setPendingAction(null);
+                  Navigator.of(context).pop();
+                },
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () {
+                  context.read<AdminFrequentMenuEditViewModel>().setShowConfirm(false);
+                  final action = context.read<AdminFrequentMenuEditViewModel>().pendingAction;
+                  context.read<AdminFrequentMenuEditViewModel>().setPendingAction(null);
+                  Navigator.of(context).pop();
+                  action?.call();
+                },
+                child: const Text('나가기'),
+              ),
+            ],
+          ),
+        );
+      });
+    }
+
+    return WillPopScope(
+      onWillPop: () => _confirmDiscardIfDirty(vm),
+      child: Scaffold(
+        appBar: AppBar(
+          toolbarHeight: 48,
+          backgroundColor: Colors.white,
+          elevation: 0,
+          title: Text(widget.groupId == null ? '자주 쓰는 메뉴 추가' : '자주 쓰는 메뉴 수정',
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+          centerTitle: true,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
+            onPressed: () async {
+              final ok = await _confirmDiscardIfDirty(vm);
+              if (!ok) return;
+              if (!context.mounted) return;
+              Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu/frequent', (r) => false);
+            },
+          ),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: ElevatedButton(
+                onPressed: vm.saving ? null : () => context.read<AdminFrequentMenuEditViewModel>().save(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFF97316),
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  minimumSize: Size.zero,
+                ),
+                child: vm.saving
+                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
+                    : const Text('저장', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+              ),
+            ),
+          ],
+        ),
+        body: Stack(
+          children: [
+            Container(
+              color: const Color(0xFFF5F6F7),
+              child: Column(
+                children: [
+                  if (vm.loading)
+                    const Expanded(child: Center(child: CircularProgressIndicator()))
+                  else
+                    Expanded(
+                      child: ListView(
+                        padding: const EdgeInsets.all(16),
+                        children: [
+                          _InputBar(
+                            controller: _controller,
+                            onChanged: (v) => context.read<AdminFrequentMenuEditViewModel>().setInput(v),
+                            onAdd: () => context.read<AdminFrequentMenuEditViewModel>().addMenu(),
+                          ),
+                          const SizedBox(height: 16),
+                          _MenuList(
+                            menus: vm.menus,
+                            onRemove: (i) => context.read<AdminFrequentMenuEditViewModel>().removeMenu(i),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            if (vm.showSavedToast)
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 24),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                    decoration: BoxDecoration(color: const Color(0xFF111827), borderRadius: BorderRadius.circular(999)),
+                    child: const Text('저장되었습니다', style: TextStyle(color: Colors.white, fontSize: 12)),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InputBar extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onAdd;
+
+  const _InputBar({required this.controller, required this.onChanged, required this.onAdd});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: '메뉴 입력',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+                ),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                isDense: true,
+              ),
+              style: const TextStyle(fontSize: 14),
+              onChanged: onChanged,
+              onSubmitted: (_) => onAdd(),
+              textInputAction: TextInputAction.done,
+              controller: controller,
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: onAdd,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFE5E7EB),
+              foregroundColor: const Color(0xFF111827),
+              elevation: 0,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              minimumSize: const Size(60, 40),
+            ),
+            child: const Text('입력', style: TextStyle(fontSize: 14)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuList extends StatelessWidget {
+  final List<String> menus;
+  final ValueChanged<int> onRemove;
+
+  const _MenuList({required this.menus, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    if (menus.isEmpty) {
+      return const Center(
+        child: Text('현재 작성된 메뉴가 없습니다', style: TextStyle(color: Color(0xFF9CA3AF), fontSize: 14, fontWeight: FontWeight.w600)),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int i = 0; i < menus.length; i++)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 16,
+                  child: Text(
+                    '${i + 1}',
+                    textAlign: TextAlign.right,
+                    style: const TextStyle(fontSize: 14, color: Color(0xFF6B7280)),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Container(width: 1, height: 20, color: const Color(0xFFD1D5DB)),
+                const SizedBox(width: 12),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFF7ED), // orange-50
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        menus[i],
+                        style: const TextStyle(fontSize: 14, color: Color(0xFF1F2937)),
+                      ),
+                      const SizedBox(width: 8),
+                      GestureDetector(
+                        onTap: () => onRemove(i),
+                        child: const Text(
+                          '✕',
+                          style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/admin/screens/admin_frequent_menu_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_screen.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/menu_models.dart';
+import '../viewmodels/admin_frequent_menu_view_model.dart';
+import 'admin_frequent_menu_edit_screen.dart';
+
+class AdminFrequentMenuScreen extends StatefulWidget {
+  static const routeName = '/admin/menu/frequent';
+
+  const AdminFrequentMenuScreen({super.key});
+
+  @override
+  State<AdminFrequentMenuScreen> createState() => _AdminFrequentMenuScreenState();
+}
+
+class _AdminFrequentMenuScreenState extends State<AdminFrequentMenuScreen> {
+  bool _loaded = false;
+  bool _selectMode = false;
+  final Set<int> _selectedIds = <int>{};
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminFrequentMenuViewModel>().init());
+  }
+
+  void _toggleSelect(int groupId) {
+    setState(() {
+      if (_selectedIds.contains(groupId)) {
+        _selectedIds.remove(groupId);
+      } else {
+        _selectedIds.add(groupId);
+      }
+    });
+  }
+
+  Future<void> _handleDelete() async {
+    if (_selectedIds.isEmpty) return;
+    final vm = context.read<AdminFrequentMenuViewModel>();
+    await vm.deleteGroups(_selectedIds.toList());
+    setState(() {
+      _selectedIds.clear();
+      _selectMode = false;
+    });
+  }
+
+  Widget _buildRightElement() {
+    if (_selectMode) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextButton(
+            onPressed: () {
+              setState(() {
+                _selectMode = false;
+                _selectedIds.clear();
+              });
+            },
+            child: const Text('취소', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF6B7280))),
+          ),
+          TextButton(
+            onPressed: _selectedIds.isEmpty
+                ? null
+                : () async {
+                    final confirmed = await showDialog<bool>(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        title: const Text('삭제하시겠습니까?'),
+                        content: const Text('이 동작은 취소할 수 없습니다'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text('취소'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text('삭제', style: TextStyle(color: Color(0xFFEF4444))),
+                          ),
+                        ],
+                      ),
+                    );
+                    if (confirmed == true) {
+                      await _handleDelete();
+                    }
+                  },
+            style: TextButton.styleFrom(
+              foregroundColor: _selectedIds.isEmpty ? const Color(0xFF9CA3AF) : const Color(0xFFF97316),
+            ),
+            child: const Text('삭제', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+          ),
+        ],
+      );
+    } else {
+      return TextButton(
+        onPressed: () {
+          setState(() {
+            _selectMode = true;
+          });
+        },
+        child: const Text('선택', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF9CA3AF))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<AdminFrequentMenuViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        toolbarHeight: 48,
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: Text(_selectMode ? '' : '자주 쓰는 메뉴', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
+          onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu', (r) => false),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: _buildRightElement(),
+          ),
+        ],
+      ),
+      body: Container(
+        color: const Color(0xFFF5F6F7),
+        child: vm.loading && vm.groups.isEmpty
+            ? const Center(child: CircularProgressIndicator())
+            : Column(
+                children: [
+                  Expanded(
+                    child: vm.groups.isEmpty
+                        ? const Center(child: Text('자주 쓰는 메뉴가 없습니다', style: TextStyle(fontSize: 14, color: Color(0xFF9CA3AF))))
+                        : ListView.builder(
+                            padding: const EdgeInsets.all(16),
+                            itemCount: vm.groups.length,
+                            itemBuilder: (context, index) {
+                              final group = vm.groups[index];
+                              return _FrequentMenuRow(
+                                group: group,
+                                selectMode: _selectMode,
+                                isSelected: _selectedIds.contains(group.groupId),
+                                onTap: () {
+                                  if (_selectMode) {
+                                    _toggleSelect(group.groupId);
+                                  } else {
+                                    Navigator.of(context).pushNamed(
+                                      AdminFrequentMenuEditScreen.routeName,
+                                      arguments: group.groupId,
+                                    );
+                                  }
+                                },
+                              );
+                            },
+                          ),
+                  ),
+                  if (vm.errorMessage != null)
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                      color: const Color(0xFFFFF1F2),
+                      child: Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
+                    ),
+                  if (!_selectMode)
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Center(
+                        child: FloatingActionButton(
+                          onPressed: () => Navigator.of(context).pushNamed(AdminFrequentMenuEditScreen.routeName),
+                          backgroundColor: const Color(0xFFD1D5DB),
+                          child: const Icon(Icons.add, color: Colors.white),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+      ),
+    );
+  }
+}
+
+class _FrequentMenuRow extends StatelessWidget {
+  final FavoriteGroup group;
+  final bool selectMode;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _FrequentMenuRow({
+    required this.group,
+    required this.selectMode,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 1),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          top: BorderSide(color: Color(0xFFE5E7EB), width: 1),
+        ),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          height: 50,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  group.menu.join(', '),
+                  style: const TextStyle(fontSize: 14, color: Color(0xFF6B7280)),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (selectMode)
+                Checkbox(
+                  value: isSelected,
+                  onChanged: (_) => onTap(),
+                  activeColor: const Color(0xFFE5E7EB),
+                )
+              else
+                const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/admin/screens/admin_frequent_menu_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_screen.dart
@@ -168,7 +168,7 @@ class _AdminFrequentMenuScreenState extends State<AdminFrequentMenuScreen> {
                     ),
                   if (!_selectMode)
                     Padding(
-                      padding: const EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(60),
                       child: Center(
                         child: FloatingActionButton(
                           onPressed: () => Navigator.of(context).pushNamed(AdminFrequentMenuEditScreen.routeName),

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -35,15 +35,18 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        toolbarHeight: 48,
+        backgroundColor: Colors.white,
+        elevation: 0,
         title: const Text(''),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
           onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/', (r) => false),
         ),
         actions: [
           IconButton(
             onPressed: () => _showToast(context, '준비중입니다'),
-            icon: const Icon(Icons.settings),
+            icon: const Icon(Icons.settings, color: Color(0xFF111827)),
           ),
         ],
       ),

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -107,7 +107,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
             const SizedBox(height: 12),
             _WideCard(
               title: '메뉴 관리',
-              onTap: () => _showToast(context, '다음 이슈에서 구현 예정'),
+              onTap: () => Navigator.of(context).pushNamed('/admin/menu'),
             ),
             const SizedBox(height: 16),
             SizedBox(

--- a/lib/features/admin/screens/admin_inventory_screen.dart
+++ b/lib/features/admin/screens/admin_inventory_screen.dart
@@ -39,9 +39,12 @@ class _AdminInventoryScreenState extends State<AdminInventoryScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        toolbarHeight: 48,
+        backgroundColor: Colors.white,
+        elevation: 0,
         title: const Text(''),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
           onPressed: () => Navigator.of(context).maybePop(),
         ),
       ),

--- a/lib/features/admin/screens/admin_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_menu_edit_screen.dart
@@ -1,0 +1,411 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../common/utils/week_kst.dart';
+import '../viewmodels/admin_menu_edit_view_model.dart';
+
+class AdminMenuEditScreen extends StatefulWidget {
+  static const routeName = '/admin/menu/edit';
+
+  final String? initialDate; // YYYY-MM-DD
+
+  const AdminMenuEditScreen({super.key, this.initialDate});
+
+  @override
+  State<AdminMenuEditScreen> createState() => _AdminMenuEditScreenState();
+}
+
+class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
+  bool _loaded = false;
+  Timer? _toastTimer;
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _toastTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminMenuEditViewModel>().load());
+  }
+
+  Future<bool> _confirmDiscardIfDirty(AdminMenuEditViewModel vm) async {
+    if (!vm.dirty) return true;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('변경사항이 있어요'),
+        content: const Text('저장하지 않고 나갈까요?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(false), child: const Text('취소')),
+          TextButton(onPressed: () => Navigator.of(context).pop(true), child: const Text('나가기')),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<AdminMenuEditViewModel>();
+
+    if (_controller.text != vm.input) {
+      _controller.value = TextEditingValue(
+        text: vm.input,
+        selection: TextSelection.collapsed(offset: vm.input.length),
+      );
+    }
+
+    // toast (저장되었습니다)
+    if (vm.showSavedToast) {
+      _toastTimer?.cancel();
+      _toastTimer = Timer(const Duration(milliseconds: 700), () {
+        if (!mounted) return;
+        context.read<AdminMenuEditViewModel>().hideToast();
+      });
+    }
+
+    // 웹 UI처럼 월~일(7일) 표시
+    final days = List.generate(7, (i) => addDaysYmd(vm.mondayId, i));
+
+    return WillPopScope(
+      onWillPop: () => _confirmDiscardIfDirty(vm),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('메뉴 수정'),
+          centerTitle: true,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () async {
+              final ok = await _confirmDiscardIfDirty(vm);
+              if (!ok) return;
+              if (!context.mounted) return;
+              Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu', (r) => false);
+            },
+          ),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: ElevatedButton(
+                onPressed: vm.saving ? null : () => context.read<AdminMenuEditViewModel>().save(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFF97316),
+                  foregroundColor: Colors.white,
+                  elevation: 0,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                ),
+                child: Text(vm.saving ? '저장중...' : '저장', style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+              ),
+            ),
+          ],
+        ),
+        body: Stack(
+          children: [
+            Container(
+              color: Colors.white,
+              child: Column(
+                children: [
+                  _WeekNavigator(
+                    mondayId: vm.mondayId,
+                    selectedId: vm.selectedId,
+                    days: days,
+                    onPrevWeek: () async {
+                      final ok = await _confirmDiscardIfDirty(vm);
+                      if (!ok) return;
+                      await vm.shiftWeek(-1);
+                    },
+                    onNextWeek: () async {
+                      final ok = await _confirmDiscardIfDirty(vm);
+                      if (!ok) return;
+                      await vm.shiftWeek(1);
+                    },
+                    onSelect: (id) async {
+                      final ok = await _confirmDiscardIfDirty(vm);
+                      if (!ok) return;
+                      await vm.selectDate(id);
+                    },
+                  ),
+                  if (vm.loading)
+                    const Expanded(child: Center(child: CircularProgressIndicator()))
+                  else
+                    Expanded(
+                      child: ListView(
+                        padding: const EdgeInsets.all(16),
+                        children: [
+                          _InputBar(
+                            controller: _controller,
+                            onChanged: (v) => context.read<AdminMenuEditViewModel>().setInput(v),
+                            onAdd: () => context.read<AdminMenuEditViewModel>().addMenu(),
+                            onTapMenu: () {
+                              // 다음 단계에서 '자주 쓰는 메뉴' 연동 예정
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('자주 쓰는 메뉴는 다음 단계에서 구현 예정'), duration: Duration(milliseconds: 900)),
+                              );
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          _MenuList(
+                            menus: vm.menus,
+                            onRemove: (i) => context.read<AdminMenuEditViewModel>().removeMenu(i),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            if (vm.showSavedToast)
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 24),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                    decoration: BoxDecoration(color: const Color(0xFF111827), borderRadius: BorderRadius.circular(999)),
+                    child: const Text('저장되었습니다', style: TextStyle(color: Colors.white, fontSize: 12)),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WeekNavigator extends StatelessWidget {
+  final String mondayId;
+  final String selectedId;
+  final List<String> days;
+  final VoidCallback onPrevWeek;
+  final VoidCallback onNextWeek;
+  final ValueChanged<String> onSelect;
+
+  const _WeekNavigator({
+    required this.mondayId,
+    required this.selectedId,
+    required this.days,
+    required this.onPrevWeek,
+    required this.onNextWeek,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const weekdayLabels = ['월', '화', '수', '목', '금', '토', '일'];
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(bottom: BorderSide(color: Color(0xFFE5E7EB), width: 1)),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: onPrevWeek,
+            icon: const Icon(Icons.chevron_left, size: 20),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            color: const Color(0xFF374151),
+          ),
+          Expanded(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                for (int i = 0; i < days.length; i++)
+                  Flexible(
+                    child: GestureDetector(
+                      onTap: () => onSelect(days[i]),
+                      child: Container(
+                        constraints: const BoxConstraints(minWidth: 36),
+                        height: 52,
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: days[i] == selectedId ? const Color(0xFFF97316) : Colors.transparent,
+                            width: 1,
+                          ),
+                        ),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              weekdayLabels[i.clamp(0, 6)],
+                              style: const TextStyle(fontSize: 11, color: Color(0xFF6B7280)),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              days[i].substring(8), // DD
+                              style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: Color(0xFF111827)),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: onNextWeek,
+            icon: const Icon(Icons.chevron_right, size: 20),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            color: const Color(0xFF374151),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InputBar extends StatelessWidget {
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onAdd;
+  final VoidCallback onTapMenu;
+
+  const _InputBar({required this.controller, required this.onChanged, required this.onAdd, required this.onTapMenu});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 4),
+      child: Row(
+        children: [
+          InkWell(
+            onTap: onTapMenu,
+            borderRadius: BorderRadius.circular(8),
+            child: Container(
+              constraints: const BoxConstraints(minWidth: 40),
+              height: 40,
+              decoration: BoxDecoration(
+                color: const Color(0xFFE5E7EB),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(Icons.menu, color: Color(0xFF374151), size: 20),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: '메뉴 입력',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+                ),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                isDense: true,
+              ),
+              style: const TextStyle(fontSize: 14),
+              onChanged: onChanged,
+              onSubmitted: (_) => onAdd(),
+              textInputAction: TextInputAction.done,
+              controller: controller,
+            ),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: onAdd,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFE5E7EB),
+              foregroundColor: const Color(0xFF111827),
+              elevation: 0,
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              minimumSize: const Size(60, 40),
+            ),
+            child: const Text('입력', style: TextStyle(fontSize: 14)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MenuList extends StatelessWidget {
+  final List<String> menus;
+  final ValueChanged<int> onRemove;
+
+  const _MenuList({required this.menus, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    if (menus.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 180),
+        child: Text('현재 작성된 메뉴가 없습니다', style: TextStyle(color: Color(0xFF9CA3AF), fontSize: 14, fontWeight: FontWeight.w600)),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int i = 0; i < menus.length; i++)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 16,
+                  child: Text(
+                    '${i + 1}',
+                    textAlign: TextAlign.right,
+                    style: const TextStyle(fontSize: 14, color: Color(0xFF6B7280)),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Container(width: 1, height: 20, color: const Color(0xFFD1D5DB)),
+                const SizedBox(width: 12),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFF7ED), // orange-50
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        menus[i],
+                        style: const TextStyle(fontSize: 14, color: Color(0xFF1F2937)),
+                      ),
+                      const SizedBox(width: 8),
+                      GestureDetector(
+                        onTap: () => onRemove(i),
+                        child: const Text(
+                          '✕',
+                          style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+

--- a/lib/features/admin/screens/admin_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_menu_edit_screen.dart
@@ -80,10 +80,13 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
       onWillPop: () => _confirmDiscardIfDirty(vm),
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('메뉴 수정'),
+          toolbarHeight: 48,
+          backgroundColor: Colors.white,
+          elevation: 0,
+          title: const Text('메뉴 수정', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
           centerTitle: true,
           leading: IconButton(
-            icon: const Icon(Icons.arrow_back),
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
             onPressed: () async {
               final ok = await _confirmDiscardIfDirty(vm);
               if (!ok) return;
@@ -102,8 +105,9 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
                   elevation: 0,
                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  minimumSize: const Size(40, 20),
                 ),
-                child: Text(vm.saving ? '저장중...' : '저장', style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                child: Text('저장', style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
               ),
             ),
           ],
@@ -203,7 +207,7 @@ class _WeekNavigator extends StatelessWidget {
   Widget build(BuildContext context) {
     const weekdayLabels = ['월', '화', '수', '목', '금', '토', '일'];
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
       decoration: const BoxDecoration(
         color: Colors.white,
         border: Border(bottom: BorderSide(color: Color(0xFFE5E7EB), width: 1)),
@@ -212,9 +216,9 @@ class _WeekNavigator extends StatelessWidget {
         children: [
           IconButton(
             onPressed: onPrevWeek,
-            icon: const Icon(Icons.chevron_left, size: 20),
+            icon: const Icon(Icons.chevron_left, size: 18),
             padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
             color: const Color(0xFF374151),
           ),
           Expanded(
@@ -227,7 +231,7 @@ class _WeekNavigator extends StatelessWidget {
                       onTap: () => onSelect(days[i]),
                       child: Container(
                         constraints: const BoxConstraints(minWidth: 36),
-                        height: 52,
+                        height: 44,
                         padding: const EdgeInsets.symmetric(horizontal: 4),
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(12),
@@ -242,12 +246,12 @@ class _WeekNavigator extends StatelessWidget {
                           children: [
                             Text(
                               weekdayLabels[i.clamp(0, 6)],
-                              style: const TextStyle(fontSize: 11, color: Color(0xFF6B7280)),
+                              style: const TextStyle(fontSize: 10, color: Color(0xFF6B7280)),
                             ),
-                            const SizedBox(height: 2),
+                            const SizedBox(height: 1),
                             Text(
                               days[i].substring(8), // DD
-                              style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600, color: Color(0xFF111827)),
+                              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF111827)),
                             ),
                           ],
                         ),
@@ -259,9 +263,9 @@ class _WeekNavigator extends StatelessWidget {
           ),
           IconButton(
             onPressed: onNextWeek,
-            icon: const Icon(Icons.chevron_right, size: 20),
+            icon: const Icon(Icons.chevron_right, size: 18),
             padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+            constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
             color: const Color(0xFF374151),
           ),
         ],
@@ -352,8 +356,7 @@ class _MenuList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (menus.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 180),
+      return const Center(
         child: Text('현재 작성된 메뉴가 없습니다', style: TextStyle(color: Color(0xFF9CA3AF), fontSize: 14, fontWeight: FontWeight.w600)),
       );
     }

--- a/lib/features/admin/screens/admin_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_menu_edit_screen.dart
@@ -149,12 +149,6 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
                             controller: _controller,
                             onChanged: (v) => context.read<AdminMenuEditViewModel>().setInput(v),
                             onAdd: () => context.read<AdminMenuEditViewModel>().addMenu(),
-                            onTapMenu: () {
-                              // 다음 단계에서 '자주 쓰는 메뉴' 연동 예정
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('자주 쓰는 메뉴는 다음 단계에서 구현 예정'), duration: Duration(milliseconds: 900)),
-                              );
-                            },
                           ),
                           const SizedBox(height: 16),
                           _MenuList(
@@ -278,9 +272,8 @@ class _InputBar extends StatelessWidget {
   final TextEditingController controller;
   final ValueChanged<String> onChanged;
   final VoidCallback onAdd;
-  final VoidCallback onTapMenu;
 
-  const _InputBar({required this.controller, required this.onChanged, required this.onAdd, required this.onTapMenu});
+  const _InputBar({required this.controller, required this.onChanged, required this.onAdd});
 
   @override
   Widget build(BuildContext context) {
@@ -288,20 +281,6 @@ class _InputBar extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(4, 0, 4, 4),
       child: Row(
         children: [
-          InkWell(
-            onTap: onTapMenu,
-            borderRadius: BorderRadius.circular(8),
-            child: Container(
-              constraints: const BoxConstraints(minWidth: 40),
-              height: 40,
-              decoration: BoxDecoration(
-                color: const Color(0xFFE5E7EB),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: const Icon(Icons.menu, color: Color(0xFF374151), size: 20),
-            ),
-          ),
-          const SizedBox(width: 8),
           Expanded(
             child: TextField(
               decoration: InputDecoration(

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -64,6 +64,23 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
           icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
           onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/admin', (r) => false),
         ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: TextButton(
+              onPressed: () => Navigator.of(context).pushNamed('/admin/menu/frequent'),
+              style: TextButton.styleFrom(
+                backgroundColor: const Color(0xFFF97316),
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700)),
+            ),
+          ),
+        ],
       ),
       body: Container(
         color: const Color(0xFFF5F6F7),

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../../common/utils/week_kst.dart';
 import '../models/admin_menu_week.dart';
+import 'admin_menu_edit_screen.dart';
 import '../viewmodels/admin_menu_view_model.dart';
 
 class AdminMenuScreen extends StatefulWidget {
@@ -115,7 +116,10 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
                             key: key,
                             child: _WeekCard(
                               week: week,
-                              onTapDay: (ymd) => _toast(context, '메뉴 수정 화면은 다음 단계에서 구현 예정 ($ymd)'),
+                              onTapDay: (ymd) => Navigator.of(context).pushNamed(
+                                AdminMenuEditScreen.routeName,
+                                arguments: ymd,
+                              ),
                             ),
                           );
                         },

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -69,12 +69,6 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
         color: const Color(0xFFF5F6F7),
         child: Column(
           children: [
-            // "헤더로 취급"되는 영역: ActionBar까지 포함
-            _ActionBar(
-              onTapCalendar: () => _toast(context, '다음 단계에서 구현 예정'),
-              onTapFrequent: () => _toast(context, '다음 단계에서 구현 예정'),
-            ),
-
             Expanded(
               child: vm.loading && vm.weeks.isEmpty
                   ? const Center(child: CircularProgressIndicator())
@@ -142,51 +136,6 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
     );
   }
 
-  static void _toast(BuildContext context, String msg) {
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg), duration: const Duration(milliseconds: 900)));
-  }
-}
-
-class _ActionBar extends StatelessWidget {
-  final VoidCallback onTapCalendar;
-  final VoidCallback onTapFrequent;
-
-  const _ActionBar({required this.onTapCalendar, required this.onTapFrequent});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      color: Colors.white,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          TextButton.icon(
-            onPressed: onTapCalendar,
-            icon: const Icon(Icons.calendar_today, size: 16, color: Color(0xFF4B5563)),
-            label: const Text('다른 주 보기', style: TextStyle(fontSize: 13, color: Color(0xFF4B5563))),
-            style: TextButton.styleFrom(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              minimumSize: Size.zero,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-          ),
-          TextButton(
-            onPressed: onTapFrequent,
-            style: TextButton.styleFrom(
-              backgroundColor: const Color(0xFFF97316),
-              foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
-              minimumSize: Size.zero,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-            child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700)),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 class _WeekCard extends StatelessWidget {

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/admin_menu_week.dart';
+import '../viewmodels/admin_menu_view_model.dart';
+
+class AdminMenuScreen extends StatefulWidget {
+  static const routeName = '/admin/menu';
+
+  const AdminMenuScreen({super.key});
+
+  @override
+  State<AdminMenuScreen> createState() => _AdminMenuScreenState();
+}
+
+class _AdminMenuScreenState extends State<AdminMenuScreen> {
+  final _scroll = ScrollController();
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scroll.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scroll.removeListener(_onScroll);
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    final vm = context.read<AdminMenuViewModel>();
+    if (!_scroll.hasClients) return;
+    if (_scroll.position.extentAfter < 300) {
+      vm.loadNextWeek();
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_loaded) return;
+    _loaded = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminMenuViewModel>().init());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<AdminMenuViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('메뉴 관리'),
+        centerTitle: true,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/admin', (r) => false),
+        ),
+      ),
+      body: Container(
+        color: const Color(0xFFF5F6F7),
+        child: Column(
+          children: [
+            _ActionBar(
+              onTapCalendar: () => _toast(context, '다음 단계에서 구현 예정'),
+              onTapFrequent: () => _toast(context, '다음 단계에서 구현 예정'),
+            ),
+            Expanded(
+              child: vm.loading && vm.weeks.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : RefreshIndicator(
+                      onRefresh: () async => _toast(context, 'pull-to-prev는 다음 단계에서 구현 예정'),
+                      child: ListView.builder(
+                        controller: _scroll,
+                        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                        itemCount: vm.weeks.length + 1,
+                        itemBuilder: (context, idx) {
+                          if (idx == vm.weeks.length) {
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 16),
+                              child: Center(
+                                child: vm.loadingNext
+                                    ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                                    : const SizedBox.shrink(),
+                              ),
+                            );
+                          }
+
+                          final week = vm.weeks[idx];
+                          return _WeekCard(
+                            week: week,
+                            onTapDay: (ymd) => _toast(context, '메뉴 수정 화면은 다음 단계에서 구현 예정 ($ymd)'),
+                          );
+                        },
+                      ),
+                    ),
+            ),
+            if (vm.errorMessage != null)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                color: const Color(0xFFFFF1F2),
+                child: Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static void _toast(BuildContext context, String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg), duration: const Duration(milliseconds: 900)));
+  }
+}
+
+class _ActionBar extends StatelessWidget {
+  final VoidCallback onTapCalendar;
+  final VoidCallback onTapFrequent;
+
+  const _ActionBar({required this.onTapCalendar, required this.onTapFrequent});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          TextButton.icon(
+            onPressed: onTapCalendar,
+            icon: const Icon(Icons.calendar_today, size: 18, color: Color(0xFF4B5563)),
+            label: const Text('다른 주 보기', style: TextStyle(color: Color(0xFF4B5563))),
+          ),
+          TextButton(
+            onPressed: onTapFrequent,
+            style: TextButton.styleFrom(
+              backgroundColor: const Color(0xFFF97316),
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+            ),
+            child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WeekCard extends StatelessWidget {
+  final List<AdminMenuDay> week;
+  final ValueChanged<String> onTapDay;
+
+  const _WeekCard({required this.week, required this.onTapDay});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+      ),
+      child: Column(
+        children: [
+          for (int i = 0; i < week.length; i++) ...[
+            _DayRow(day: week[i], onTap: () => onTapDay(week[i].id)),
+            if (i != week.length - 1) const Divider(height: 1, color: Color(0xFFE5E7EB)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _DayRow extends StatelessWidget {
+  final AdminMenuDay day;
+  final VoidCallback onTap;
+
+  const _DayRow({required this.day, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = day.items.isNotEmpty ? day.items.join(', ') : '메뉴 없음';
+    final opacity = day.isPast ? 0.4 : 1.0;
+
+    return Opacity(
+      opacity: opacity,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 64,
+                child: Text(
+                  day.dateLabel,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: day.isToday ? FontWeight.w800 : FontWeight.w600,
+                    color: day.isToday ? const Color(0xFFF97316) : const Color(0xFF6B7280),
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: 40,
+                child: Text(day.weekdayLabel, style: const TextStyle(fontSize: 13, color: Color(0xFF6B7280))),
+              ),
+              Expanded(
+                child: Text(
+                  summary,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: day.items.isNotEmpty ? const Color(0xFF111827) : const Color(0xFF9CA3AF),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -55,10 +55,13 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('메뉴 관리'),
+        toolbarHeight: 48,
+        backgroundColor: Colors.white,
+        elevation: 0,
+        title: const Text('메뉴 관리', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
         centerTitle: true,
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
           onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/admin', (r) => false),
         ),
       ),
@@ -154,24 +157,31 @@ class _ActionBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       color: Colors.white,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           TextButton.icon(
             onPressed: onTapCalendar,
-            icon: const Icon(Icons.calendar_today, size: 18, color: Color(0xFF4B5563)),
-            label: const Text('다른 주 보기', style: TextStyle(color: Color(0xFF4B5563))),
+            icon: const Icon(Icons.calendar_today, size: 16, color: Color(0xFF4B5563)),
+            label: const Text('다른 주 보기', style: TextStyle(fontSize: 13, color: Color(0xFF4B5563))),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
           ),
           TextButton(
             onPressed: onTapFrequent,
             style: TextButton.styleFrom(
               backgroundColor: const Color(0xFFF97316),
               foregroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
             ),
-            child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w700)),
+            child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700)),
           ),
         ],
       ),

--- a/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../repositories/admin_repository.dart';
+
+class AdminFrequentMenuEditViewModel extends ChangeNotifier {
+  AdminFrequentMenuEditViewModel(this._repo, {this.groupId});
+
+  final AdminRepository _repo;
+  final int? groupId; // null이면 새로 만들기, 있으면 수정
+
+  bool loading = false;
+  bool saving = false;
+  String? errorMessage;
+  List<String> menus = [];
+  String input = '';
+  bool dirty = false;
+  bool showConfirm = false;
+  VoidCallback? pendingAction;
+  bool showSavedToast = false;
+
+  Future<void> init() async {
+    if (groupId == null) return; // 새로 만들기는 로딩 불필요
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final res = await _repo.getFavoriteGroup(groupId: groupId!);
+      if (res.groups.isNotEmpty) {
+        menus = List<String>.from(res.groups.first.menu);
+      }
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '자주 쓰는 메뉴 불러오기 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  void setInput(String value) {
+    input = value;
+    notifyListeners();
+  }
+
+  void addMenu() {
+    final text = input.trim();
+    if (text.isEmpty) return;
+    menus = [...menus, text];
+    input = '';
+    dirty = true;
+    notifyListeners();
+  }
+
+  void removeMenu(int index) {
+    menus = menus.asMap().entries.where((entry) => entry.key != index).map((entry) => entry.value).toList();
+    dirty = true;
+    notifyListeners();
+  }
+
+  Future<void> save() async {
+    saving = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      if (groupId == null) {
+        await _repo.createFavorite(menus: menus);
+      } else {
+        await _repo.updateFavorite(groupId: groupId!, menus: menus);
+      }
+      dirty = false;
+      showSavedToast = true;
+      notifyListeners();
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '저장 실패';
+      }
+    } finally {
+      saving = false;
+      notifyListeners();
+    }
+  }
+
+  void hideToast() {
+    showSavedToast = false;
+    notifyListeners();
+  }
+
+  void setDirty(bool value) {
+    dirty = value;
+    notifyListeners();
+  }
+
+  void setShowConfirm(bool value) {
+    showConfirm = value;
+    notifyListeners();
+  }
+
+  void setPendingAction(VoidCallback? action) {
+    pendingAction = action;
+    notifyListeners();
+  }
+}

--- a/lib/features/admin/viewmodels/admin_frequent_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_frequent_menu_view_model.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../models/menu_models.dart';
+import '../repositories/admin_repository.dart';
+
+class AdminFrequentMenuViewModel extends ChangeNotifier {
+  AdminFrequentMenuViewModel(this._repo);
+
+  final AdminRepository _repo;
+
+  bool loading = false;
+  String? errorMessage;
+  List<FavoriteGroup> groups = [];
+
+  Future<void> init() async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final res = await _repo.getFavorites();
+      groups = res.groups;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '자주 쓰는 메뉴 불러오기 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteGroups(List<int> groupIds) async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      await _repo.deleteFavorites(groupIds: groupIds);
+      groups = groups.where((g) => !groupIds.contains(g.groupId)).toList();
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '삭제 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refresh() async {
+    await init();
+  }
+}

--- a/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../../../common/utils/kst_date.dart';
+import '../../../common/utils/week_kst.dart';
+import '../repositories/admin_repository.dart';
+
+class AdminMenuEditViewModel extends ChangeNotifier {
+  AdminMenuEditViewModel(this._repo, {String? initialDate})
+      : selectedId = initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd(),
+        mondayId = mondayOfYmd(initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd());
+
+  final AdminRepository _repo;
+
+  String selectedId; // YYYY-MM-DD
+  String mondayId; // YYYY-MM-DD (monday)
+
+  bool loading = false;
+  bool saving = false;
+  bool dirty = false;
+  String input = '';
+  String? errorMessage;
+
+  List<String> menus = [];
+
+  bool showSavedToast = false;
+
+  Future<void> load() async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final res = await _repo.getDailyMenu(date: selectedId);
+      menus = res?.menus ?? <String>[];
+      dirty = false;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '메뉴 불러오기 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  void setInput(String v) {
+    input = v;
+    notifyListeners();
+  }
+
+  void addMenu([String? menuText]) {
+    final text = (menuText ?? input).trim();
+    if (text.isEmpty) return;
+    menus = [...menus, text];
+    if (menuText == null) input = '';
+    dirty = true;
+    notifyListeners();
+  }
+
+  void removeMenu(int idx) {
+    if (idx < 0 || idx >= menus.length) return;
+    final next = List<String>.from(menus);
+    next.removeAt(idx);
+    menus = next;
+    dirty = true;
+    notifyListeners();
+  }
+
+  Future<void> save() async {
+    if (saving) return;
+    saving = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      await _repo.saveDailyMenu(date: selectedId, menus: menus);
+      dirty = false;
+      showSavedToast = true;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '저장 실패';
+      }
+    } finally {
+      saving = false;
+      notifyListeners();
+    }
+  }
+
+  void hideToast() {
+    if (!showSavedToast) return;
+    showSavedToast = false;
+    notifyListeners();
+  }
+
+  Future<void> selectDate(String ymd) async {
+    if (ymd == selectedId) return;
+    selectedId = ymd;
+    mondayId = mondayOfYmd(ymd);
+    await load();
+  }
+
+  Future<void> shiftWeek(int deltaWeeks) async {
+    final nextMonday = addWeeksYmd(mondayId, deltaWeeks);
+    // 편집 화면은 mondayId를 선택 날짜로 사용(웹과 동일하게 monday로 이동)
+    await selectDate(nextMonday);
+  }
+}
+

--- a/lib/features/admin/viewmodels/admin_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_view_model.dart
@@ -31,10 +31,11 @@ class AdminMenuViewModel extends ChangeNotifier {
     notifyListeners();
     try {
       final monday = mondayOfYmd(todayYmd);
-      // iOS(특히 SE)에서는 "1주(월~금)"만으로 화면이 꽉 차서 스크롤이 안 되는 것처럼 보일 수 있어
-      // 초기 2주를 로드해서 스크롤/무한로딩 UX를 확보한다.
+      // 초기 4주를 로드해서 충분한 스크롤/무한로딩 UX를 확보한다.
       await _loadWeek(baseDate: monday, direction: 'next', force: true);
       await _loadWeek(baseDate: addWeeksYmd(monday, 1), direction: 'next', force: true);
+      await _loadWeek(baseDate: addWeeksYmd(monday, 2), direction: 'next', force: true);
+      await _loadWeek(baseDate: addWeeksYmd(monday, 3), direction: 'next', force: true);
     } catch (e) {
       if (e is ApiException) {
         errorMessage = mapErrorToMessage(e, responseData: e.details);

--- a/lib/features/admin/viewmodels/admin_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_view_model.dart
@@ -155,5 +155,6 @@ class AdminMenuViewModel extends ChangeNotifier {
     final parts = ymd.split('-');
     return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
   }
+
 }
 

--- a/lib/features/admin/viewmodels/admin_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_view_model.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../common/dio/api_error_mapper.dart';
+import '../../../common/dio/api_exception.dart';
+import '../../../common/utils/kst_date.dart';
+import '../../../common/utils/week_kst.dart';
+import '../models/admin_menu_week.dart';
+import '../models/menu_models.dart';
+import '../repositories/admin_repository.dart';
+
+class AdminMenuViewModel extends ChangeNotifier {
+  AdminMenuViewModel(this._repo);
+
+  final AdminRepository _repo;
+
+  bool loading = false;
+  bool loadingNext = false;
+  String? errorMessage;
+
+  /// weeks[0] is the top-most week.
+  final List<List<AdminMenuDay>> weeks = [];
+  final Set<String> _loadedMondays = <String>{};
+
+  String todayYmd = kstTodayYmd();
+
+  Future<void> init() async {
+    if (weeks.isNotEmpty) return;
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final monday = mondayOfYmd(todayYmd);
+      await _loadWeek(baseDate: monday, direction: 'next', force: true);
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '주간 메뉴 불러오기 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadNextWeek() async {
+    if (loadingNext || weeks.isEmpty) return;
+    loadingNext = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final lastWeek = weeks.last;
+      final lastMonday = mondayOfYmd(lastWeek.first.id);
+      final nextMonday = addWeeksYmd(lastMonday, 1);
+      await _loadWeek(baseDate: nextMonday, direction: 'next', force: false);
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '다음 주 불러오기 실패';
+      }
+    } finally {
+      loadingNext = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadWeek({
+    required String baseDate,
+    required String direction, // 'prev' | 'next'
+    required bool force,
+  }) async {
+    final monday = mondayOfYmd(baseDate);
+    if (!force && _loadedMondays.contains(monday)) return;
+    if (weeks.any((w) => mondayOfYmd(w.first.id) == monday)) {
+      _loadedMondays.add(monday);
+      return;
+    }
+
+    final res = await _repo.getWeeklyMenu(date: baseDate);
+    final week = _buildWeekFromApiOrEmpty(res, monday);
+    if (direction == 'next') {
+      weeks.add(week);
+    } else {
+      weeks.insert(0, week);
+    }
+    _loadedMondays.add(monday);
+  }
+
+  List<AdminMenuDay> _buildWeekFromApiOrEmpty(WeeklyMenuResponse res, String monday) {
+    // 요구사항: 주간 리스트는 월~금(5일)만
+    final map = <String, WeeklyMenuDay>{};
+    for (final d in res.dailyMenus) {
+      map[d.date] = d;
+    }
+
+    final result = <AdminMenuDay>[];
+    for (int i = 0; i < 5; i++) {
+      final ymd = addDaysYmd(monday, i);
+      final dt = _parseYmdLocal(ymd);
+      final dateLabel = '${dt.month.toString().padLeft(2, '0')}.${dt.day.toString().padLeft(2, '0')}';
+      const weekdayLabels = ['월', '화', '수', '목', '금', '토', '일'];
+      final weekdayLabel = weekdayLabels[(dt.weekday - 1).clamp(0, 6)];
+
+      final api = map[ymd];
+      final items = api?.menus ?? <String>[];
+
+      final isPast = dt.isBefore(_parseYmdLocal(todayYmd));
+      final isToday = ymd == todayYmd;
+
+      result.add(
+        AdminMenuDay(
+          id: ymd,
+          dateLabel: dateLabel,
+          weekdayLabel: weekdayLabel,
+          items: items,
+          isPast: isPast,
+          isToday: isToday,
+        ),
+      );
+    }
+    return result;
+  }
+
+  DateTime _parseYmdLocal(String ymd) {
+    final parts = ymd.split('-');
+    return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,8 +18,10 @@ import 'features/admin/data/admin_api.dart';
 import 'features/admin/repositories/admin_repository.dart';
 import 'features/admin/screens/admin_home_screen.dart';
 import 'features/admin/screens/admin_inventory_screen.dart';
+import 'features/admin/screens/admin_menu_screen.dart';
 import 'features/admin/viewmodels/admin_home_view_model.dart';
 import 'features/admin/viewmodels/admin_inventory_view_model.dart';
+import 'features/admin/viewmodels/admin_menu_view_model.dart';
 import 'features/auth/models/role.dart';
 import 'features/mypage/screens/change_email_screen.dart';
 import 'features/mypage/screens/mypage_screen.dart';
@@ -72,6 +74,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo, adminApi)),
         ChangeNotifierProvider(create: (_) => AdminInventoryViewModel(adminRepo)),
+        ChangeNotifierProvider(create: (_) => AdminMenuViewModel(adminRepo)),
       ],
       child: MaterialApp(
         title: '1000meal App',
@@ -92,6 +95,10 @@ class MyApp extends StatelessWidget {
           AdminInventoryScreen.routeName: (_) => const RoleGuard(
                 targetRole: Role.admin,
                 child: AdminInventoryScreen(),
+              ),
+          AdminMenuScreen.routeName: (_) => const RoleGuard(
+                targetRole: Role.admin,
+                child: AdminMenuScreen(),
               ),
           MyPageScreen.routeName: (_) => const RoleGuard(
                 targetRole: Role.student,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,10 +20,14 @@ import 'features/admin/screens/admin_home_screen.dart';
 import 'features/admin/screens/admin_inventory_screen.dart';
 import 'features/admin/screens/admin_menu_screen.dart';
 import 'features/admin/screens/admin_menu_edit_screen.dart';
+import 'features/admin/screens/admin_frequent_menu_screen.dart';
+import 'features/admin/screens/admin_frequent_menu_edit_screen.dart';
 import 'features/admin/viewmodels/admin_home_view_model.dart';
 import 'features/admin/viewmodels/admin_inventory_view_model.dart';
 import 'features/admin/viewmodels/admin_menu_view_model.dart';
 import 'features/admin/viewmodels/admin_menu_edit_view_model.dart';
+import 'features/admin/viewmodels/admin_frequent_menu_view_model.dart';
+import 'features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart';
 import 'features/auth/models/role.dart';
 import 'features/mypage/screens/change_email_screen.dart';
 import 'features/mypage/screens/mypage_screen.dart';
@@ -116,6 +120,29 @@ class MyApp extends StatelessWidget {
                         initialDate: initialDate,
                       ),
                       child: AdminMenuEditScreen(initialDate: initialDate),
+                    );
+                  },
+                ),
+              ),
+          AdminFrequentMenuScreen.routeName: (context) => RoleGuard(
+                targetRole: Role.admin,
+                child: ChangeNotifierProvider(
+                  create: (_) => AdminFrequentMenuViewModel(context.read<AdminRepository>()),
+                  child: const AdminFrequentMenuScreen(),
+                ),
+              ),
+          AdminFrequentMenuEditScreen.routeName: (context) => RoleGuard(
+                targetRole: Role.admin,
+                child: Builder(
+                  builder: (context) {
+                    final args = ModalRoute.of(context)?.settings.arguments;
+                    final groupId = args is int ? args : null;
+                    return ChangeNotifierProvider(
+                      create: (_) => AdminFrequentMenuEditViewModel(
+                        context.read<AdminRepository>(),
+                        groupId: groupId,
+                      ),
+                      child: AdminFrequentMenuEditScreen(groupId: groupId),
                     );
                   },
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,9 +19,11 @@ import 'features/admin/repositories/admin_repository.dart';
 import 'features/admin/screens/admin_home_screen.dart';
 import 'features/admin/screens/admin_inventory_screen.dart';
 import 'features/admin/screens/admin_menu_screen.dart';
+import 'features/admin/screens/admin_menu_edit_screen.dart';
 import 'features/admin/viewmodels/admin_home_view_model.dart';
 import 'features/admin/viewmodels/admin_inventory_view_model.dart';
 import 'features/admin/viewmodels/admin_menu_view_model.dart';
+import 'features/admin/viewmodels/admin_menu_edit_view_model.dart';
 import 'features/auth/models/role.dart';
 import 'features/mypage/screens/change_email_screen.dart';
 import 'features/mypage/screens/mypage_screen.dart';
@@ -100,6 +102,22 @@ class MyApp extends StatelessWidget {
                 child: ChangeNotifierProvider(
                   create: (_) => AdminMenuViewModel(context.read<AdminRepository>()),
                   child: const AdminMenuScreen(),
+                ),
+              ),
+          AdminMenuEditScreen.routeName: (context) => RoleGuard(
+                targetRole: Role.admin,
+                child: Builder(
+                  builder: (context) {
+                    final args = ModalRoute.of(context)?.settings.arguments;
+                    final initialDate = args is String ? args : null;
+                    return ChangeNotifierProvider(
+                      create: (_) => AdminMenuEditViewModel(
+                        context.read<AdminRepository>(),
+                        initialDate: initialDate,
+                      ),
+                      child: AdminMenuEditScreen(initialDate: initialDate),
+                    );
+                  },
                 ),
               ),
           MyPageScreen.routeName: (_) => const RoleGuard(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,7 +74,6 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => AdminHomeViewModel(authRepo, adminApi)),
         ChangeNotifierProvider(create: (_) => AdminInventoryViewModel(adminRepo)),
-        ChangeNotifierProvider(create: (_) => AdminMenuViewModel(adminRepo)),
       ],
       child: MaterialApp(
         title: '1000meal App',
@@ -96,9 +95,12 @@ class MyApp extends StatelessWidget {
                 targetRole: Role.admin,
                 child: AdminInventoryScreen(),
               ),
-          AdminMenuScreen.routeName: (_) => const RoleGuard(
+          AdminMenuScreen.routeName: (context) => RoleGuard(
                 targetRole: Role.admin,
-                child: AdminMenuScreen(),
+                child: ChangeNotifierProvider(
+                  create: (_) => AdminMenuViewModel(context.read<AdminRepository>()),
+                  child: const AdminMenuScreen(),
+                ),
               ),
           MyPageScreen.routeName: (_) => const RoleGuard(
                 targetRole: Role.student,


### PR DESCRIPTION
## 📋 개요

웹(Next.js)에서 제공하던 관리자 메뉴관리 기능을 Flutter로 마이그레이션 완료했습니다.

## ✅ 구현 완료된 기능

### 1. 메뉴 관리 메인 페이지 (`/admin/menu`)
- ✅ 주간(월~금 5일) 메뉴 리스트 표시
- ✅ 항상 당일이 포함된 주가 최상단에 위치
- ✅ 초기 로딩: 오늘 포함 주 + 이후 3주 (총 4주)
- ✅ 아래로 스크롤 시 다음주 무한 로딩
- ✅ 위로 pull-to-refresh 시 이전주 추가 로딩
- ✅ 과거 날짜 흐림 처리, 당일 강조 표시
- ✅ "자주 쓰는 메뉴" 버튼 (AppBar 우측)

### 2. 메뉴 수정 페이지 (`/admin/menu/edit/:date`)
- ✅ 선택 날짜(평일) 메뉴 조회/편집/저장
- ✅ 메뉴 추가/삭제 기능
- ✅ 주 네비게이터(평일 5일 pill) + 이전주/다음주 이동
- ✅ dirty 상태에서 뒤로가기/주 이동 시 확인 모달
- ✅ 저장 완료 토스트 메시지
- ✅ "자주 쓰는 메뉴" 드롭다운 (☰ 버튼)으로 빠른 메뉴 삽입

### 3. 자주 쓰는 메뉴 관리 (`/admin/menu/frequent`)
- ✅ 목록 조회 (`GET /favorites/store/{storeId}`)
- ✅ 그룹 상세 조회 (`GET /favorites/group/{groupId}`)
- ✅ 신규 그룹 생성 (`POST /favorites/{storeId}`)
- ✅ 그룹 수정 (`PUT /favorites/{groupId}`)
- ✅ 다건 삭제 (`DELETE /favorites/{storeId}/groups`)
- ✅ 선택 모드(체크박스) + 삭제 확인 모달
- ✅ 메뉴 편집 화면에서 드롭다운으로 즐겨찾기 삽입

## 🔧 기술 구현 사항

### 아키텍처
- **MVVM + Provider**: `ChangeNotifierProvider` 기반 상태 관리
- **Repository Pattern**: `AdminRepository`에서 토큰/스토어ID 처리
- **API Layer**: `DioClient` 기반, 에러 매핑 포함

### 주요 컴포넌트
- `AdminMenuViewModel`: 주간 리스트 상태 관리, 무한 스크롤, pull-to-prev
- `AdminMenuEditViewModel`: 일일 메뉴 편집, dirty 상태, 즐겨찾기 연동
- `AdminFrequentMenuViewModel`: 즐겨찾기 그룹 목록 관리
- `AdminFrequentMenuEditViewModel`: 즐겨찾기 그룹 편집

### 날짜 처리
- KST(Asia/Seoul) 고정: `kstTodayYmd()`, `mondayOfYmd()` 등 유틸 함수 사용
- YYYY-MM-DD 형식 일관성 유지

### UX 개선
- 초기 로딩 주 수: 2주 → 4주로 증가 (더 많은 정보 즉시 제공)
- `RefreshIndicator.adaptive`로 자연스러운 pull-to-refresh
- `WillPopScope`로 dirty 상태 확인
- Toast 메시지로 사용자 피드백 제공
- 날짜 범위 선택하여 이동하는 기능 삭제 (UX 이슈)

## 📁 변경된 파일

### 신규 파일
- `lib/features/admin/models/admin_menu_week.dart` - UI 모델
- `lib/features/admin/models/menu_models.dart` - API 응답 모델
- `lib/features/admin/viewmodels/admin_menu_view_model.dart` - 메뉴 관리 ViewModel
- `lib/features/admin/viewmodels/admin_menu_edit_view_model.dart` - 메뉴 편집 ViewModel
- `lib/features/admin/viewmodels/admin_frequent_menu_view_model.dart` - 즐겨찾기 목록 ViewModel
- `lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart` - 즐겨찾기 편집 ViewModel
- `lib/features/admin/screens/admin_menu_screen.dart` - 메뉴 관리 메인 화면
- `lib/features/admin/screens/admin_menu_edit_screen.dart` - 메뉴 편집 화면
- `lib/features/admin/screens/admin_frequent_menu_screen.dart` - 즐겨찾기 목록 화면
- `lib/features/admin/screens/admin_frequent_menu_edit_screen.dart` - 즐겨찾기 편집 화면
- `lib/common/utils/week_kst.dart` - 주간 날짜 계산 유틸

### 수정된 파일
- `lib/features/admin/data/admin_api.dart` - 주간/일일 메뉴, 즐겨찾기 API 추가
- `lib/features/admin/repositories/admin_repository.dart` - 메뉴/즐겨찾기 Repository 메서드 추가
- `lib/main.dart` - 라우트 및 Provider 등록

## ✅ 테스트

- [x] 메뉴 관리 페이지 초기 진입 시 4주치 메뉴 리스트 로딩 확인
- [x] 무한 스크롤로 다음주 계속 로딩 확인
- [x] Pull-to-refresh로 이전주 추가 로딩 확인
- [x] 메뉴 수정 페이지에서 메뉴 추가/삭제/저장 동작 확인
- [x] Dirty 상태에서 뒤로가기 시 확인 모달 표시 확인
- [x] 자주 쓰는 메뉴 목록/생성/수정/삭제 동작 확인
- [x] 메뉴 편집 화면에서 즐겨찾기 드롭다운 동작 확인
- [x] RoleGuard로 관리자 권한 확인
- [x] `flutter analyze` 오류 없음

## 📝 관련 이슈

Closes #12