### PR TITLE
Refactor/17 menugroup

### DIFF
--- a/lib/common/dio/dio_client.dart
+++ b/lib/common/dio/dio_client.dart
@@ -122,6 +122,29 @@ class DioClient {
       );
     }
   }
+
+  Future<T> patch<T>(
+    String path, {
+    Object? data,
+    Map<String, dynamic>? queryParameters,
+    Map<String, String>? headers,
+  }) async {
+    try {
+      final res = await _dio.patch<T>(
+        path,
+        data: data,
+        queryParameters: queryParameters,
+        options: Options(headers: headers),
+      );
+      return res.data as T;
+    } on DioException catch (e) {
+      throw ApiException(
+        e.message ?? '네트워크 오류가 발생했습니다.',
+        statusCode: e.response?.statusCode,
+        details: e.response?.data,
+      );
+    }
+  }
 }
 
 

--- a/lib/features/admin/data/admin_api.dart
+++ b/lib/features/admin/data/admin_api.dart
@@ -30,7 +30,7 @@ class AdminApi {
 
   Future<DailyMenuResponse?> getDailyMenu({required int storeId, required String date, required String token}) async {
     final root = await _client.get<Map<String, dynamic>>(
-      '/menus/daily/$storeId/groups/',
+      '/menus/daily/$storeId/groups',
       queryParameters: {'date': date},
       headers: {'Authorization': 'Bearer $token'},
     );
@@ -130,7 +130,7 @@ class AdminApi {
     required String token,
   }) async {
     final root = await _client.post<Map<String, dynamic>>(
-      '/menus/daily/$storeId/groups/',
+      '/menus/daily/$storeId/groups',
       queryParameters: {'date': date},
       headers: {'Authorization': 'Bearer $token'},
       data: {'menus': menus},

--- a/lib/features/admin/data/admin_api.dart
+++ b/lib/features/admin/data/admin_api.dart
@@ -30,7 +30,7 @@ class AdminApi {
 
   Future<DailyMenuResponse?> getDailyMenu({required int storeId, required String date, required String token}) async {
     final root = await _client.get<Map<String, dynamic>>(
-      '/menus/daily/$storeId',
+      '/menus/daily/$storeId/groups/',
       queryParameters: {'date': date},
       headers: {'Authorization': 'Bearer $token'},
     );
@@ -44,17 +44,9 @@ class AdminApi {
     return DailyMenuResponse.fromJson(unwrapped);
   }
 
-  Future<void> updateDailyStock({required int menuId, required int stock, required String token}) async {
-    await _client.post<Object>(
-      '/menus/daily/stock/$menuId',
-      headers: {'Authorization': 'Bearer $token'},
-      data: {'stock': stock},
-    );
-  }
-
   Future<WeeklyMenuResponse> getWeeklyMenu({required int storeId, required String date, required String token}) async {
     final root = await _client.get<Map<String, dynamic>>(
-      '/menus/weekly/$storeId',
+      '/menus/daily/weekly/$storeId/groups',
       queryParameters: {'date': date},
       headers: {'Authorization': 'Bearer $token'},
     );
@@ -63,6 +55,74 @@ class AdminApi {
     return WeeklyMenuResponse.fromJson(unwrapped);
   }
 
+  // ────────────────────────────────────────────────────────────────────────────
+  // Menu-group 기반 API
+  // ────────────────────────────────────────────────────────────────────────────
+
+  Future<Map<String, dynamic>> createMenuGroup({
+    required int storeId,
+    required String name,
+    required int sortOrder,
+    required int capacity,
+    required String token,
+  }) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/menus/daily/$storeId/groups',
+      headers: {'Authorization': 'Bearer $token'},
+      data: {
+        'name': name,
+        'sortOrder': sortOrder,
+        'capacity': capacity,
+      },
+    );
+    return _unwrapData(root);
+  }
+
+  Future<MenuGroupMenusResponse> upsertMenuGroupMenus({
+    required int groupId,
+    required String date,
+    required List<String> menus,
+    required String token,
+  }) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/menus/daily/groups/$groupId/menus',
+      queryParameters: {'date': date},
+      headers: {'Authorization': 'Bearer $token'},
+      data: {'menus': menus},
+    );
+    return MenuGroupMenusResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<Map<String, dynamic>> updateMenuGroupStock({
+    required int groupId,
+    required int stock,
+    required String token,
+  }) async {
+    final root = await _client.post<Map<String, dynamic>>(
+      '/menus/daily/groups/$groupId/stock',
+      headers: {'Authorization': 'Bearer $token'},
+      data: {'stock': stock},
+    );
+    return _unwrapData(root);
+  }
+
+  Future<Map<String, dynamic>> deductMenuGroupStock({
+    required int groupId,
+    required DeductionUnit deductionUnit,
+    required String token,
+  }) async {
+    final root = await _client.patch<Map<String, dynamic>>(
+      '/menus/daily/groups/$groupId/deduct',
+      queryParameters: {'deductionUnit': deductionUnit.apiValue},
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    return _unwrapData(root);
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 레거시 호환 (Next.js도 deprecated로 유지 중)
+  // ────────────────────────────────────────────────────────────────────────────
+
   Future<DailyMenuResponse> saveDailyMenu({
     required int storeId,
     required String date,
@@ -70,11 +130,20 @@ class AdminApi {
     required String token,
   }) async {
     final root = await _client.post<Map<String, dynamic>>(
-      '/menus/daily/$storeId',
+      '/menus/daily/$storeId/groups/',
+      queryParameters: {'date': date},
       headers: {'Authorization': 'Bearer $token'},
-      data: {'date': date, 'menus': menus},
+      data: {'menus': menus},
     );
     return DailyMenuResponse.fromJson(_unwrapData(root));
+  }
+
+  Future<void> updateDailyStock({required int menuId, required int stock, required String token}) async {
+    await _client.post<Object>(
+      '/menus/daily/group/$menuId/stock',
+      headers: {'Authorization': 'Bearer $token'},
+      data: {'stock': stock},
+    );
   }
 
   // 자주 쓰는 메뉴 API

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -1,87 +1,93 @@
-class DailyMenuResponse {
-  final int id;
-  final String date; // YYYY-MM-DD
-  final String dayOfWeek; // MONDAY, TUESDAY ...
-  final int? stock;
-  final List<String> menus;
-  final bool open;
+int _toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+bool _toBool(dynamic v) {
+  if (v is bool) return v;
+  if (v is num) return v != 0;
+  final s = v?.toString().trim().toLowerCase();
+  if (s == null || s.isEmpty) return false;
+  return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+}
 
-  DailyMenuResponse({
-    required this.id,
-    required this.date,
-    required this.dayOfWeek,
+/// 주간 조회 시 하루에 해당하는 그룹 하나 (GET /menus/daily/weekly/{storeId}/groups)
+class WeeklyDayGroup {
+  final int groupId;
+  final String name;
+  final int sortOrder;
+  final int stock;
+  final int capacity;
+  final List<String> menus;
+
+  WeeklyDayGroup({
+    required this.groupId,
+    required this.name,
+    required this.sortOrder,
     required this.stock,
+    required this.capacity,
     required this.menus,
-    required this.open,
   });
 
-  factory DailyMenuResponse.fromJson(Map<String, dynamic> json) {
-    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
-    int? toIntNullable(dynamic v) => v == null ? null : (v is int ? v : int.tryParse(v.toString()));
-    bool toBool(dynamic v) {
-      if (v is bool) return v;
-      if (v is num) return v != 0;
-      final s = v?.toString().trim().toLowerCase();
-      if (s == null || s.isEmpty) return false;
-      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
-    }
-
+  factory WeeklyDayGroup.fromJson(Map<String, dynamic> json) {
     final rawMenus = json['menus'];
     final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
 
-    return DailyMenuResponse(
-      id: toInt(json['id']),
-      date: (json['date'] ?? '').toString(),
-      dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
-      stock: toIntNullable(json['stock']),
+    return WeeklyDayGroup(
+      groupId: _toInt(json['groupId']),
+      name: (json['name'] ?? '').toString(),
+      sortOrder: _toInt(json['sortOrder']),
+      stock: _toInt(json['stock']),
+      capacity: _toInt(json['capacity']),
       menus: menus,
-      open: toBool(json['open']),
     );
   }
 }
 
+/// GET /menus/daily/weekly/{storeId}/groups?date= 응답의 day item
 class WeeklyMenuDay {
   final int id;
   final String date; // YYYY-MM-DD
-  final String dayOfWeek; // 월, 화, ... or MONDAY...
-  final int? stock;
-  final List<String> menus;
+  final String dayOfWeek; // MONDAY, ...
+  final bool holiday;
+  final int totalStock;
+  final List<WeeklyDayGroup> groups;
   final bool open;
 
   WeeklyMenuDay({
     required this.id,
     required this.date,
     required this.dayOfWeek,
-    required this.stock,
-    required this.menus,
+    required this.holiday,
+    required this.totalStock,
+    required this.groups,
     required this.open,
   });
 
-  factory WeeklyMenuDay.fromJson(Map<String, dynamic> json) {
-    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
-    int? toIntNullable(dynamic v) => v == null ? null : (v is int ? v : int.tryParse(v.toString()));
-    bool toBool(dynamic v) {
-      if (v is bool) return v;
-      if (v is num) return v != 0;
-      final s = v?.toString().trim().toLowerCase();
-      if (s == null || s.isEmpty) return false;
-      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+  /// 임시 호환용: 기존 UI가 "문자열 메뉴 리스트"를 기대할 때 사용.
+  List<String> get flattenedMenus {
+    final out = <String>[];
+    for (final g in groups) {
+      out.addAll(g.menus);
     }
+    return out;
+  }
 
-    final rawMenus = json['menus'];
-    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+  factory WeeklyMenuDay.fromJson(Map<String, dynamic> json) {
+    final list = json['groups'];
+    final groups = list is List
+        ? list.whereType<Map>().map((e) => WeeklyDayGroup.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <WeeklyDayGroup>[];
 
     return WeeklyMenuDay(
-      id: toInt(json['id']),
+      id: _toInt(json['id']),
       date: (json['date'] ?? '').toString(),
       dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
-      stock: toIntNullable(json['stock']),
-      menus: menus,
-      open: toBool(json['open']),
+      holiday: _toBool(json['holiday']),
+      totalStock: _toInt(json['totalStock']),
+      groups: groups,
+      open: _toBool(json['open']),
     );
   }
 }
 
+/// GET /menus/daily/weekly/{storeId}/groups?date= 응답
 class WeeklyMenuResponse {
   final int storeId;
   final String startDate;
@@ -96,18 +102,142 @@ class WeeklyMenuResponse {
   });
 
   factory WeeklyMenuResponse.fromJson(Map<String, dynamic> json) {
-    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
     final list = json['dailyMenus'];
     final daily = list is List
         ? list.whereType<Map>().map((e) => WeeklyMenuDay.fromJson(e.cast<String, dynamic>())).toList(growable: false)
         : <WeeklyMenuDay>[];
 
     return WeeklyMenuResponse(
-      storeId: toInt(json['storeId']),
+      storeId: _toInt(json['storeId']),
       startDate: (json['startDate'] ?? '').toString(),
       endDate: (json['endDate'] ?? '').toString(),
       dailyMenus: daily,
     );
+  }
+}
+
+/// GET /menus/daily/{storeId}/groups?date= 응답의 그룹 한 개
+class DailyMenuGroupItem {
+  final int id;
+  final String name;
+  final int sortOrder;
+  final int stock;
+  final int capacity;
+  final List<String> menus;
+
+  DailyMenuGroupItem({
+    required this.id,
+    required this.name,
+    required this.sortOrder,
+    required this.stock,
+    required this.capacity,
+    required this.menus,
+  });
+
+  factory DailyMenuGroupItem.fromJson(Map<String, dynamic> json) {
+    final rawMenus = json['menus'];
+    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+
+    return DailyMenuGroupItem(
+      id: _toInt(json['id']),
+      name: (json['name'] ?? '').toString(),
+      sortOrder: _toInt(json['sortOrder']),
+      stock: _toInt(json['stock']),
+      capacity: _toInt(json['capacity']),
+      menus: menus,
+    );
+  }
+}
+
+/// GET /menus/daily/{storeId}/groups?date= 응답 (특정 날짜의 그룹 목록 + 재고)
+class DailyMenuResponse {
+  final int id;
+  final String date; // YYYY-MM-DD
+  final String dayOfWeek; // MONDAY, ...
+  final int totalStock;
+  final List<DailyMenuGroupItem> groups;
+  final bool open;
+  final bool? holiday;
+
+  DailyMenuResponse({
+    required this.id,
+    required this.date,
+    required this.dayOfWeek,
+    required this.totalStock,
+    required this.groups,
+    required this.open,
+    required this.holiday,
+  });
+
+  /// 임시 호환용: 기존 UI가 "문자열 메뉴 리스트"를 기대할 때 사용.
+  List<String> get flattenedMenus {
+    final out = <String>[];
+    for (final g in groups) {
+      out.addAll(g.menus);
+    }
+    return out;
+  }
+
+  factory DailyMenuResponse.fromJson(Map<String, dynamic> json) {
+    final list = json['groups'];
+    final groups = list is List
+        ? list.whereType<Map>().map((e) => DailyMenuGroupItem.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <DailyMenuGroupItem>[];
+
+    return DailyMenuResponse(
+      id: _toInt(json['id']),
+      date: (json['date'] ?? '').toString(),
+      dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
+      totalStock: _toInt(json['totalStock']),
+      groups: groups,
+      open: _toBool(json['open']),
+      holiday: json.containsKey('holiday') ? _toBool(json['holiday']) : null,
+    );
+  }
+}
+
+/// 메뉴 그룹 특정 날짜 메뉴 upsert 응답
+class MenuGroupMenusResponse {
+  final int id;
+  final int groupId;
+  final String groupName;
+  final String date;
+  final List<String> menus;
+
+  MenuGroupMenusResponse({
+    required this.id,
+    required this.groupId,
+    required this.groupName,
+    required this.date,
+    required this.menus,
+  });
+
+  factory MenuGroupMenusResponse.fromJson(Map<String, dynamic> json) {
+    final rawMenus = json['menus'];
+    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+
+    return MenuGroupMenusResponse(
+      id: _toInt(json['id']),
+      groupId: _toInt(json['groupId']),
+      groupName: (json['groupName'] ?? '').toString(),
+      date: (json['date'] ?? '').toString(),
+      menus: menus,
+    );
+  }
+}
+
+enum DeductionUnit { single, multiFive, multiTen }
+
+extension DeductionUnitValue on DeductionUnit {
+  String get apiValue {
+    switch (this) {
+      case DeductionUnit.single:
+        return 'SINGLE';
+      case DeductionUnit.multiFive:
+        return 'MULTI_FIVE';
+      case DeductionUnit.multiTen:
+        return 'MULTI_TEN';
+    }
   }
 }
 

--- a/lib/features/admin/models/menu_models.dart
+++ b/lib/features/admin/models/menu_models.dart
@@ -250,12 +250,16 @@ class FavoriteGroup {
     required this.menu,
   });
 
+  /// 명확한 네이밍을 위한 별칭(기존 필드와 동일 의미)
+  int get id => groupId;
+  List<String> get menus => menu;
+
   factory FavoriteGroup.fromJson(Map<String, dynamic> json) {
     final rawMenus = json['menu'];
     final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
 
     return FavoriteGroup(
-      groupId: json['groupId'] as int,
+      groupId: _toInt(json['groupId']),
       menu: menus,
     );
   }

--- a/lib/features/admin/repositories/admin_repository.dart
+++ b/lib/features/admin/repositories/admin_repository.dart
@@ -67,6 +67,47 @@ class AdminRepository {
     return _api.saveDailyMenu(storeId: storeId, date: date, menus: menus, token: token);
   }
 
+  Future<Map<String, dynamic>> createMenuGroup({
+    required String name,
+    required int sortOrder,
+    required int capacity,
+  }) async {
+    final token = await _requireToken();
+    final storeId = await _requireStoreId(token);
+    return _api.createMenuGroup(
+      storeId: storeId,
+      name: name,
+      sortOrder: sortOrder,
+      capacity: capacity,
+      token: token,
+    );
+  }
+
+  Future<MenuGroupMenusResponse> upsertMenuGroupMenus({
+    required int groupId,
+    required String date,
+    required List<String> menus,
+  }) async {
+    final token = await _requireToken();
+    return _api.upsertMenuGroupMenus(groupId: groupId, date: date, menus: menus, token: token);
+  }
+
+  Future<Map<String, dynamic>> updateMenuGroupStock({
+    required int groupId,
+    required int stock,
+  }) async {
+    final token = await _requireToken();
+    return _api.updateMenuGroupStock(groupId: groupId, stock: stock, token: token);
+  }
+
+  Future<Map<String, dynamic>> deductMenuGroupStock({
+    required int groupId,
+    required DeductionUnit deductionUnit,
+  }) async {
+    final token = await _requireToken();
+    return _api.deductMenuGroupStock(groupId: groupId, deductionUnit: deductionUnit, token: token);
+  }
+
   // 자주 쓰는 메뉴 API
   Future<FavoritesResponse> getFavorites() async {
     final token = await _requireToken();

--- a/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
@@ -106,7 +106,13 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
     }
 
     return WillPopScope(
-      onWillPop: () => _confirmDiscardIfDirty(vm),
+      onWillPop: () async {
+        final ok = await _confirmDiscardIfDirty(vm);
+        if (!ok) return false;
+        if (!context.mounted) return false;
+        Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu/frequent', (r) => false);
+        return false;
+      },
       child: Scaffold(
         appBar: AppBar(
           toolbarHeight: 48,

--- a/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
@@ -108,10 +108,7 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
     return WillPopScope(
       onWillPop: () async {
         final ok = await _confirmDiscardIfDirty(vm);
-        if (!ok) return false;
-        if (!context.mounted) return false;
-        Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu/frequent', (r) => false);
-        return false;
+        return ok;
       },
       child: Scaffold(
         appBar: AppBar(
@@ -127,7 +124,7 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
               final ok = await _confirmDiscardIfDirty(vm);
               if (!ok) return;
               if (!context.mounted) return;
-              Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu/frequent', (r) => false);
+              Navigator.of(context).maybePop();
             },
           ),
           actions: [
@@ -212,29 +209,52 @@ class _InputBar extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: TextField(
-              decoration: InputDecoration(
-                hintText: '메뉴 입력',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
+            child: SizedBox(
+              height: 40,
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: '메뉴 입력',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1), // stone-300
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  isDense: true,
+                  suffixIconConstraints: const BoxConstraints.tightFor(width: 40, height: 40),
+                  suffixIcon: controller.text.isEmpty
+                      ? null
+                      : Center(
+                          child: InkWell(
+                            onTap: () => onChanged(''),
+                            borderRadius: BorderRadius.circular(999),
+                            child: Container(
+                              width: 15,
+                              height: 15,
+                              decoration: const BoxDecoration(
+                                color: Color(0xFFA1A1A1), // neutral-400
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Center(
+                                child: Icon(Icons.close, size: 10, color: Colors.white),
+                              ),
+                            ),
+                          ),
+                        ),
                 ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
-                ),
-                contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                isDense: true,
+                style: const TextStyle(fontSize: 14),
+                onChanged: onChanged,
+                onSubmitted: (_) => onAdd(),
+                textInputAction: TextInputAction.done,
+                controller: controller,
               ),
-              style: const TextStyle(fontSize: 14),
-              onChanged: onChanged,
-              onSubmitted: (_) => onAdd(),
-              textInputAction: TextInputAction.done,
-              controller: controller,
             ),
           ),
           const SizedBox(width: 8),
@@ -248,7 +268,7 @@ class _InputBar extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               minimumSize: const Size(60, 40),
             ),
-            child: const Text('입력', style: TextStyle(fontSize: 14)),
+            child: const Text('입력', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
           ),
         ],
       ),
@@ -303,13 +323,21 @@ class _MenuList extends StatelessWidget {
                         style: const TextStyle(fontSize: 14, color: Color(0xFF1F2937)),
                       ),
                       const SizedBox(width: 8),
-                      GestureDetector(
-                        onTap: () => onRemove(i),
-                        child: const Text(
-                          '✕',
-                          style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+                        InkWell(
+                          onTap: () => onRemove(i),
+                          borderRadius: BorderRadius.circular(999),
+                          child: Container(
+                            width: 15,
+                            height: 15,
+                            decoration: const BoxDecoration(
+                              color: Color(0xFFA1A1A1), // neutral-400
+                              shape: BoxShape.circle,
+                            ),
+                            child: const Center(
+                              child: Icon(Icons.close, size: 10, color: Colors.white),
+                            ),
+                          ),
                         ),
-                      ),
                     ],
                   ),
                 ),

--- a/lib/features/admin/screens/admin_frequent_menu_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_screen.dart
@@ -118,7 +118,7 @@ class _AdminFrequentMenuScreenState extends State<AdminFrequentMenuScreen> {
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
-          onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu', (r) => false),
+          onPressed: () => Navigator.of(context).maybePop(),
         ),
         actions: [
           Padding(
@@ -127,6 +127,14 @@ class _AdminFrequentMenuScreenState extends State<AdminFrequentMenuScreen> {
           ),
         ],
       ),
+      floatingActionButton: _selectMode
+          ? null
+          : FloatingActionButton(
+              onPressed: () => Navigator.of(context).pushNamed(AdminFrequentMenuEditScreen.routeName),
+              backgroundColor: const Color(0xFFD1D5DB),
+              child: const Icon(Icons.add, color: Colors.white),
+            ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       body: Container(
         color: const Color(0xFFF5F6F7),
         child: vm.loading && vm.groups.isEmpty
@@ -136,27 +144,31 @@ class _AdminFrequentMenuScreenState extends State<AdminFrequentMenuScreen> {
                   Expanded(
                     child: vm.groups.isEmpty
                         ? const Center(child: Text('자주 쓰는 메뉴가 없습니다', style: TextStyle(fontSize: 14, color: Color(0xFF9CA3AF))))
-                        : ListView.builder(
-                            padding: const EdgeInsets.all(16),
-                            itemCount: vm.groups.length,
-                            itemBuilder: (context, index) {
-                              final group = vm.groups[index];
-                              return _FrequentMenuRow(
-                                group: group,
-                                selectMode: _selectMode,
-                                isSelected: _selectedIds.contains(group.groupId),
-                                onTap: () {
-                                  if (_selectMode) {
-                                    _toggleSelect(group.groupId);
-                                  } else {
-                                    Navigator.of(context).pushNamed(
-                                      AdminFrequentMenuEditScreen.routeName,
-                                      arguments: group.groupId,
-                                    );
-                                  }
-                                },
-                              );
-                            },
+                        : RefreshIndicator.adaptive(
+                            onRefresh: () => context.read<AdminFrequentMenuViewModel>().refresh(),
+                            child: ListView.builder(
+                              physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
+                              padding: const EdgeInsets.all(16),
+                              itemCount: vm.groups.length,
+                              itemBuilder: (context, index) {
+                                final group = vm.groups[index];
+                                return _FrequentMenuRow(
+                                  group: group,
+                                  selectMode: _selectMode,
+                                  isSelected: _selectedIds.contains(group.id),
+                                  onTap: () {
+                                    if (_selectMode) {
+                                      _toggleSelect(group.id);
+                                    } else {
+                                      Navigator.of(context).pushNamed(
+                                        AdminFrequentMenuEditScreen.routeName,
+                                        arguments: group.id,
+                                      );
+                                    }
+                                  },
+                                );
+                              },
+                            ),
                           ),
                   ),
                   if (vm.errorMessage != null)
@@ -165,17 +177,6 @@ class _AdminFrequentMenuScreenState extends State<AdminFrequentMenuScreen> {
                       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
                       color: const Color(0xFFFFF1F2),
                       child: Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
-                    ),
-                  if (!_selectMode)
-                    Padding(
-                      padding: const EdgeInsets.all(60),
-                      child: Center(
-                        child: FloatingActionButton(
-                          onPressed: () => Navigator.of(context).pushNamed(AdminFrequentMenuEditScreen.routeName),
-                          backgroundColor: const Color(0xFFD1D5DB),
-                          child: const Icon(Icons.add, color: Colors.white),
-                        ),
-                      ),
                     ),
                 ],
               ),
@@ -204,7 +205,7 @@ class _FrequentMenuRow extends StatelessWidget {
       decoration: const BoxDecoration(
         color: Colors.white,
         border: Border(
-          top: BorderSide(color: Color(0xFFE5E7EB), width: 1),
+          bottom: BorderSide(color: Color(0xFFE5E7EB), width: 1),
         ),
       ),
       child: InkWell(
@@ -216,7 +217,7 @@ class _FrequentMenuRow extends StatelessWidget {
             children: [
               Expanded(
                 child: Text(
-                  group.menu.join(', '),
+                  group.menus.join(', '),
                   style: const TextStyle(fontSize: 14, color: Color(0xFF6B7280)),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
@@ -226,7 +227,7 @@ class _FrequentMenuRow extends StatelessWidget {
                 Checkbox(
                   value: isSelected,
                   onChanged: (_) => onTap(),
-                  activeColor: const Color(0xFFE5E7EB),
+                  activeColor: const Color(0xFFF97316),
                 )
               else
                 const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 20),

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:provider/provider.dart';
 
 import '../../auth/repositories/auth_repository.dart';
+import 'admin_settings_screen.dart';
 import '../viewmodels/admin_home_view_model.dart';
 
 /// MainScreen 탭 0에서 사용: 마이페이지와 동일한 헤더 + 관리자 대시보드 본문 + (바텀바는 MainScreen에서 제공)
@@ -33,27 +34,13 @@ class _AdminTabContentState extends State<AdminTabContent> {
         backgroundColor: Colors.white,
         elevation: 0,
         scrolledUnderElevation: 0,
-        title: const Text(
-          '관리자',
-          style: TextStyle(
-            color: Color(0xFF111827),
-            fontSize: 18,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        centerTitle: false,
+        title: const SizedBox.shrink(), // 요구사항: 좌측 "관리자" 제거
+        centerTitle: true,
         leading: null,
         actions: [
           IconButton(
-            icon: SvgPicture.asset(
-              'assets/icon/alarm.svg',
-              width: 22,
-              height: 22,
-              colorFilter: const ColorFilter.mode(Color(0xFF9CA3AF), BlendMode.srcIn),
-            ),
-            onPressed: () {
-              // 알림 페이지는 별도 커밋(FCM) 범위에서 처리
-            },
+            icon: const Icon(Icons.settings, color: Color(0xFF9CA3AF), size: 22),
+            onPressed: () => Navigator.of(context).pushNamed(AdminSettingsScreen.routeName),
           ),
           const SizedBox(width: 8),
         ],

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -65,90 +65,90 @@ class _AdminDashboardBody extends StatelessWidget {
     return Container(
       color: const Color(0xFFF3F4F6),
       child: ListView(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        padding: EdgeInsets.zero,
         children: [
+          // 상단 흰색 바: 마이페이지처럼 프로필 카드 아래까지 내려오게 처리
           Container(
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(16),
-              boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+            color: Colors.white,
+            padding: const EdgeInsets.only(bottom: 20),
+            child: Container(
+              margin: const EdgeInsets.only(left: 16, right: 16, top: 8),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(color: const Color(0xFFD1D5DB), borderRadius: BorderRadius.circular(24)),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(storeName, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                    decoration: BoxDecoration(color: const Color(0xFFDBEAFE), borderRadius: BorderRadius.circular(999)),
+                    child: const Text('관리자', style: TextStyle(fontSize: 12, color: Color(0xFF2563EB), fontWeight: FontWeight.w700)),
+                  ),
+                ],
+              ),
             ),
+          ),
+          const SizedBox(height: 14),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Row(
               children: [
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(color: const Color(0xFFD1D5DB), borderRadius: BorderRadius.circular(24)),
+                Expanded(
+                  child: _OpenStatusCard(
+                    isOpen: vm.isOpen,
+                    loading: vm.loading || vm.toggling,
+                    onToggle: vm.toggling ? null : () => vm.toggleOpen(),
+                  ),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: Text(storeName, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
-                ),
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  decoration: BoxDecoration(color: const Color(0xFFDBEAFE), borderRadius: BorderRadius.circular(999)),
-                  child: const Text('관리자', style: TextStyle(fontSize: 12, color: Color(0xFF2563EB), fontWeight: FontWeight.w700)),
+                  child: _SquareCard(
+                    title: '재고 관리',
+                    subtitle: '',
+                    onTap: () {
+                      Navigator.of(context).pushNamed('/admin/inventory').then((_) {
+                        if (!context.mounted) return;
+                        context.read<AdminHomeViewModel>().load();
+                      });
+                    },
+                    trailing: const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 28),
+                  ),
                 ),
               ],
             ),
           ),
-          const SizedBox(height: 14),
-          Row(
-            children: [
-              Expanded(
-                child: _OpenStatusCard(
-                  isOpen: vm.isOpen,
-                  loading: vm.loading || vm.toggling,
-                  onToggle: vm.toggling ? null : () => vm.toggleOpen(),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: _SquareCard(
-                  title: '재고 관리',
-                  subtitle: '',
-                  onTap: () {
-                    Navigator.of(context).pushNamed('/admin/inventory').then((_) {
-                      if (!context.mounted) return;
-                      context.read<AdminHomeViewModel>().load();
-                    });
-                  },
-                  trailing: const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 28),
-                ),
-              ),
-            ],
-          ),
           const SizedBox(height: 12),
-          _WideCard(
-            title: '메뉴 관리',
-            onTap: () => Navigator.of(context).pushNamed('/admin/menu'),
-          ),
-          const SizedBox(height: 16),
-          SizedBox(
-            height: 48,
-            child: ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFFEF4444),
-                foregroundColor: Colors.white,
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-              ),
-              onPressed: () async {
-                await context.read<AuthRepository>().logout();
-                if (!context.mounted) return;
-                Navigator.of(context).pushNamedAndRemoveUntil('/', (r) => false, arguments: 3);
-              },
-              child: const Text('로그아웃', style: TextStyle(fontWeight: FontWeight.w700)),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: _WideCard(
+              title: '메뉴 관리',
+              onTap: () => Navigator.of(context).pushNamed('/admin/menu'),
             ),
           ),
+          
           if (vm.loading) ...[
             const SizedBox(height: 12),
             const Center(child: CircularProgressIndicator()),
           ],
           if (vm.errorMessage != null) ...[
             const SizedBox(height: 12),
-            Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
+            ),
           ],
+          const SizedBox(height: 16),
         ],
       ),
     );

--- a/lib/features/admin/screens/admin_home_screen.dart
+++ b/lib/features/admin/screens/admin_home_screen.dart
@@ -168,7 +168,7 @@ class _AdminDashboardBody extends StatelessWidget {
   }
 }
 
-/// /admin 라우트: MainScreen으로 리다이렉트 (탭 0 선택)하여 바텀바와 동일 레이아웃 유지.
+/// /admin 라우트: MainScreen으로 리다이렉트 (탭 3 선택)하여 바텀바와 동일 레이아웃 유지.
 /// StatefulWidget 유지 시 Hot Reload 시 기존 트리의 State 타입과 충돌하지 않음.
 class AdminHomeScreen extends StatefulWidget {
   static const routeName = '/admin';
@@ -185,7 +185,7 @@ class _AdminHomeRedirectState extends State<AdminHomeScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      Navigator.of(context).pushNamedAndRemoveUntil('/', (r) => false, arguments: 0);
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (r) => false, arguments: 3);
     });
   }
 

--- a/lib/features/admin/screens/admin_inventory_screen.dart
+++ b/lib/features/admin/screens/admin_inventory_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../models/menu_models.dart';
 import '../viewmodels/admin_inventory_view_model.dart';
 
 class AdminInventoryScreen extends StatefulWidget {
@@ -13,12 +14,14 @@ class AdminInventoryScreen extends StatefulWidget {
 }
 
 class _AdminInventoryScreenState extends State<AdminInventoryScreen> {
-  final _controller = TextEditingController();
+  final Map<int, TextEditingController> _controllers = <int, TextEditingController>{};
   bool _loaded = false;
 
   @override
   void dispose() {
-    _controller.dispose();
+    for (final c in _controllers.values) {
+      c.dispose();
+    }
     super.dispose();
   }
 
@@ -33,25 +36,45 @@ class _AdminInventoryScreenState extends State<AdminInventoryScreen> {
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<AdminInventoryViewModel>();
-    _controller.value = _controller.value.copyWith(text: vm.stock.toString(), selection: TextSelection.collapsed(offset: vm.stock.toString().length));
 
     final formatted = _formatKstKorean(vm.date);
+    final groups = vm.groupsSorted;
 
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: 48,
+        toolbarHeight: 56,
         backgroundColor: Colors.white,
         elevation: 0,
-        title: const Text(''),
+        centerTitle: true,
+        title: const Text(
+          '재고 관리',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+            color: Color(0xFF1A1A1A),
+            fontFamily: 'Pretendard',
+            height: 1.6,
+          ),
+        ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
           onPressed: () => Navigator.of(context).maybePop(),
         ),
+        actions: [
+          IconButton(
+            onPressed: (vm.loading || vm.saving) ? null : () => vm.loadToday(),
+            icon: Icon(
+              Icons.refresh,
+              color: (vm.loading || vm.saving) ? const Color(0xFFBDBDBD) : const Color(0xFFBDBDBD),
+            ),
+          ),
+          const SizedBox(width: 6),
+        ],
       ),
       body: Stack(
         children: [
           Container(
-            color: const Color(0xFFFAFAFA),
+            color: const Color(0xFFF7F7F7), // stone-50
             child: ListView(
               padding: EdgeInsets.zero,
               children: [
@@ -67,90 +90,31 @@ class _AdminInventoryScreenState extends State<AdminInventoryScreen> {
                         TextSpan(text: formatted.weekday, style: const TextStyle(color: Color(0xFFFB923C))),
                       ],
                     ),
-                  ),
-                ),
+                  ),),
 
                 // 재고 패널
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 18, 16, 16),
+                  padding: const EdgeInsets.fromLTRB(20, 18, 20, 16),
                   child: Column(
                     children: [
-                      Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
-                        decoration: BoxDecoration(
-                          color: Colors.white,
-                          borderRadius: BorderRadius.circular(16),
-                          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
+                      for (final g in groups) ...[
+                        _GroupStockCard(
+                          group: g,
+                          open: vm.open,
+                          loading: vm.loading,
+                          saving: vm.saving,
+                          stock: vm.groupStock(g.id),
+                          controller: _controllers.putIfAbsent(g.id, () => TextEditingController()),
+                          onMinus: () => vm.deductGroupStock(g.id, DeductionUnit.single),
+                          onPlus: () => vm.adjustGroupStock(g.id, 1),
+                          onChanged: (v) => vm.setGroupStockFromInput(g.id, v),
+                          onCommit: () => vm.commitGroupStock(g.id),
+                          onDeduct: (DeductionUnit unit) => vm.deductGroupStock(g.id, unit),
                         ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Text(
-                              '현재 수량',
-                              style: TextStyle(
-                                fontSize: 18,
-                                fontWeight: FontWeight.w700,
-                                color: vm.open ? const Color(0xFF111827) : const Color(0xFFD1D5DB),
-                              ),
-                            ),
-                            Row(
-                              children: [
-                                _CircleButton(
-                                  label: '–',
-                                  onTap: () => vm.adjustStock(-1),
-                                  disabled: vm.loading || vm.saving,
-                                ),
-                                const SizedBox(width: 10),
-                                SizedBox(
-                                  width: 96,
-                                  height: 48,
-                                  child: TextField(
-                                    controller: _controller,
-                                    enabled: !vm.loading && !vm.saving,
-                                    keyboardType: TextInputType.number,
-                                    textAlign: TextAlign.center,
-                                    style: TextStyle(
-                                      fontSize: 20,
-                                      fontWeight: FontWeight.w700,
-                                      color: vm.open ? const Color(0xFF111827) : const Color(0xFFD1D5DB),
-                                    ),
-                                    decoration: InputDecoration(
-                                      contentPadding: EdgeInsets.zero,
-                                      border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
-                                    ),
-                                    onChanged: vm.setStockFromInput,
-                                    onSubmitted: (_) => vm.commitStock(),
-                                    onEditingComplete: () => vm.commitStock(),
-                                  ),
-                                ),
-                                const SizedBox(width: 10),
-                                _CircleButton(
-                                  label: '+',
-                                  onTap: () => vm.adjustStock(1),
-                                  disabled: vm.loading || vm.saving,
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: 14),
-                      Container(
-                        decoration: BoxDecoration(
-                          color: Colors.white,
-                          borderRadius: BorderRadius.circular(16),
-                          boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
-                        ),
-                        child: Row(
-                          children: const [10, 5, 1].asMap().entries.map((e) {
-                            final idx = e.key;
-                            final value = e.value;
-                            return Expanded(
-                              child: _QuickMinusButton(value: value, showDivider: idx < 2),
-                            );
-                          }).toList(growable: false),
-                        ),
-                      ),
+                        const SizedBox(height: 28),
+                        const Divider(height: 1, thickness: 0.5, color: Color(0xFFBDBDBD)),
+                        const SizedBox(height: 22),
+                      ],
                       if (vm.errorMessage != null) ...[
                         const SizedBox(height: 12),
                         Text(vm.errorMessage!, style: const TextStyle(color: Color(0xFFEF4444), fontSize: 12)),
@@ -301,47 +265,244 @@ class _CircleButton extends StatelessWidget {
       onTap: disabled ? null : onTap,
       borderRadius: BorderRadius.circular(999),
       child: Container(
-        width: 28,
-        height: 28,
+        width: 20,
+        height: 20,
         decoration: BoxDecoration(
-          color: const Color(0xFFD1D5DB),
+          color: const Color(0xFFBDBDBD).withValues(alpha: 0.7), // stone-300 opacity-70
           borderRadius: BorderRadius.circular(999),
         ),
         child: Center(
-          child: Text(label, style: const TextStyle(color: Colors.white, fontSize: 18, height: 1.0)),
+          child: Text(label, style: const TextStyle(color: Colors.white, fontSize: 14, height: 1.0)),
         ),
       ),
     );
   }
 }
 
-class _QuickMinusButton extends StatelessWidget {
-  final int value;
-  final bool showDivider;
-  const _QuickMinusButton({required this.value, required this.showDivider});
+class _GroupStockCard extends StatelessWidget {
+  const _GroupStockCard({
+    required this.group,
+    required this.open,
+    required this.loading,
+    required this.saving,
+    required this.stock,
+    required this.controller,
+    required this.onMinus,
+    required this.onPlus,
+    required this.onChanged,
+    required this.onCommit,
+    required this.onDeduct,
+  });
+
+  final DailyMenuGroupItem group;
+  final bool open;
+  final bool loading;
+  final bool saving;
+  final int stock;
+  final TextEditingController controller;
+  final VoidCallback onMinus;
+  final VoidCallback onPlus;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onCommit;
+  final ValueChanged<DeductionUnit> onDeduct;
 
   @override
   Widget build(BuildContext context) {
-    final vm = context.read<AdminInventoryViewModel>();
-    return InkWell(
-      onTap: () => vm.adjustStock(-value),
-      child: Container(
-        height: 112,
-        decoration: BoxDecoration(
-          border: showDivider ? const Border(right: BorderSide(color: Color(0xFFE5E7EB))) : null,
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Container(
-              width: 20,
-              height: 20,
-              decoration: BoxDecoration(color: const Color(0xFFD1D5DB), borderRadius: BorderRadius.circular(999)),
-              child: const Center(child: Text('–', style: TextStyle(color: Colors.white, fontSize: 14, height: 1.0))),
+    controller.value = controller.value.copyWith(
+      text: stock.toString(),
+      selection: TextSelection.collapsed(offset: stock.toString().length),
+    );
+
+    final disabled = loading || saving;
+    final titleColor = open ? const Color(0xFF1A1A1A) : const Color(0xFFBDBDBD);
+
+    return SizedBox(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '[${group.name}]  현재 수량',
+            style: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFFBDBDBD),
+              fontFamily: 'Pretendard',
+              height: 1.6,
             ),
-            const SizedBox(width: 8),
-            Text('$value개', style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
-          ],
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              _CircleButton(label: '–', onTap: onMinus, disabled: disabled),
+              const SizedBox(width: 14),
+              SizedBox(
+                width: 88,
+                height: 36,
+                child: TextField(
+                  controller: controller,
+                  enabled: !disabled,
+                  keyboardType: TextInputType.number,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w600,
+                    color: titleColor,
+                    fontFamily: 'Pretendard',
+                    height: 1.0,
+                  ),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: const BorderSide(color: Color(0xFFBDBDBD), width: 0.72),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(8),
+                      borderSide: const BorderSide(color: Color(0xFFBDBDBD), width: 0.72),
+                    ),
+                  ),
+                  onChanged: onChanged,
+                  onSubmitted: (_) => onCommit(),
+                  onEditingComplete: onCommit,
+                ),
+              ),
+              const SizedBox(width: 14),
+              _CircleButton(label: '+', onTap: onPlus, disabled: disabled),
+            ],
+          ),
+          const SizedBox(height: 28),
+          _DeductRow(
+            disabled: disabled,
+            stock: stock,
+            onDeduct: onDeduct,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeductRow extends StatelessWidget {
+  const _DeductRow({
+    required this.disabled,
+    required this.stock,
+    required this.onDeduct,
+  });
+
+  final bool disabled;
+  final int stock;
+  final ValueChanged<DeductionUnit> onDeduct;
+
+  @override
+  Widget build(BuildContext context) {
+    final can10 = !disabled && stock >= 10;
+    final can5 = !disabled && stock >= 5;
+    final can1 = !disabled && stock >= 1;
+
+    return Container(
+      height: 96,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x26000000), // rgba(0,0,0,0.15)
+            blurRadius: 20,
+            offset: Offset(0, 0),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          _DeductCell(
+            label: '10개',
+            enabled: can10,
+            roundedLeft: true,
+            onTap: () => onDeduct(DeductionUnit.multiTen),
+          ),
+          _DeductCell(
+            label: '5개',
+            enabled: can5,
+            onTap: () => onDeduct(DeductionUnit.multiFive),
+          ),
+          _DeductCell(
+            label: '1개',
+            enabled: can1,
+            roundedRight: true,
+            onTap: () => onDeduct(DeductionUnit.single),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeductCell extends StatelessWidget {
+  const _DeductCell({
+    required this.label,
+    required this.enabled,
+    required this.onTap,
+    this.roundedLeft = false,
+    this.roundedRight = false,
+  });
+
+  final String label;
+  final bool enabled;
+  final VoidCallback onTap;
+  final bool roundedLeft;
+  final bool roundedRight;
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.only(
+      topLeft: roundedLeft ? const Radius.circular(16) : Radius.zero,
+      bottomLeft: roundedLeft ? const Radius.circular(16) : Radius.zero,
+      topRight: roundedRight ? const Radius.circular(16) : Radius.zero,
+      bottomRight: roundedRight ? const Radius.circular(16) : Radius.zero,
+    );
+
+    return Expanded(
+      child: InkWell(
+        onTap: enabled ? onTap : null,
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: radius,
+            border: const Border(
+              right: BorderSide(color: Color(0xFFBDBDBD), width: 0.5),
+            ),
+          ),
+          child: Center(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 20,
+                  height: 20,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFBDBDBD).withValues(alpha: 0.7),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: const Center(
+                    child: Text('–', style: TextStyle(color: Colors.white, fontSize: 14, height: 1.0)),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w600,
+                    color: enabled ? const Color(0xFFBDBDBD) : const Color(0xFFBDBDBD),
+                    fontFamily: 'Pretendard',
+                    height: 1.0,
+                    letterSpacing: 0.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/admin/screens/admin_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_menu_edit_screen.dart
@@ -84,7 +84,20 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
           toolbarHeight: 48,
           backgroundColor: Colors.white,
           elevation: 0,
-          title: const Text('메뉴 수정', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+          title: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('메뉴 수정', style: TextStyle(fontSize: 18, fontWeight: FontWeight.w700, color: Color(0xFF111827))),
+              if (vm.groupName.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Text(
+                    vm.groupName,
+                    style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600, color: Color(0xFF6B7280)),
+                  ),
+                ),
+            ],
+          ),
           centerTitle: true,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
@@ -99,7 +112,7 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
             Padding(
               padding: const EdgeInsets.only(right: 12),
               child: ElevatedButton(
-                onPressed: vm.saving ? null : () => context.read<AdminMenuEditViewModel>().save(),
+                onPressed: (vm.saving || vm.groupId == null) ? null : () => context.read<AdminMenuEditViewModel>().save(),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: const Color(0xFFF97316),
                   foregroundColor: Colors.white,
@@ -139,7 +152,16 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
                       await vm.selectDate(id);
                     },
                   ),
-                  if (vm.loading)
+                  if (vm.groupId == null)
+                    const Expanded(
+                      child: Center(
+                        child: Text(
+                          '메뉴 그룹을 선택해주세요',
+                          style: TextStyle(color: Color(0xFF6B7280), fontSize: 14, fontWeight: FontWeight.w600),
+                        ),
+                      ),
+                    )
+                  else if (vm.loading)
                     const Expanded(child: Center(child: CircularProgressIndicator()))
                   else
                     Expanded(
@@ -155,7 +177,8 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
                                 onAdd: () => context.read<AdminMenuEditViewModel>().addMenu(),
                                 onTapMenu: () async {
                                   final hasMenus = await context.read<AdminMenuEditViewModel>().toggleFrequentMenu();
-                                  if (!hasMenus && mounted) {
+                                  if (!context.mounted) return;
+                                  if (!hasMenus) {
                                     ScaffoldMessenger.of(context).showSnackBar(
                                       const SnackBar(
                                         content: Text('자주 쓰는 메뉴가 없습니다'),

--- a/lib/features/admin/screens/admin_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_menu_edit_screen.dart
@@ -78,7 +78,13 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
     final days = List.generate(7, (i) => addDaysYmd(vm.mondayId, i));
 
     return WillPopScope(
-      onWillPop: () => _confirmDiscardIfDirty(vm),
+      onWillPop: () async {
+        final ok = await _confirmDiscardIfDirty(vm);
+        if (!ok) return false;
+        if (!context.mounted) return false;
+        Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu', (r) => false);
+        return false;
+      },
       child: Scaffold(
         appBar: AppBar(
           toolbarHeight: 48,
@@ -315,7 +321,7 @@ class _WeekNavigator extends StatelessWidget {
                 for (int i = 0; i < days.length; i++)
                   Flexible(
                     child: GestureDetector(
-                      onTap: () => onSelect(days[i]),
+                      onTap: i >= 5 ? null : () => onSelect(days[i]), // ✅ 토/일 클릭 불가
                       child: Container(
                         constraints: const BoxConstraints(minWidth: 36),
                         height: 44,
@@ -323,7 +329,7 @@ class _WeekNavigator extends StatelessWidget {
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(12),
                           border: Border.all(
-                            color: days[i] == selectedId ? const Color(0xFFF97316) : Colors.transparent,
+                            color: (i < 5 && days[i] == selectedId) ? const Color(0xFFF97316) : Colors.transparent,
                             width: 1,
                           ),
                         ),
@@ -333,12 +339,19 @@ class _WeekNavigator extends StatelessWidget {
                           children: [
                             Text(
                               weekdayLabels[i.clamp(0, 6)],
-                              style: const TextStyle(fontSize: 10, color: Color(0xFF6B7280)),
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: i >= 5 ? const Color(0xFFD6D3D1) : const Color(0xFF6B7280), // stone-300 / gray
+                              ),
                             ),
                             const SizedBox(height: 1),
                             Text(
                               days[i].substring(8), // DD
-                              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Color(0xFF111827)),
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: i >= 5 ? const Color(0xFFD6D3D1) : const Color(0xFF111827), // stone-300 / zinc-900
+                              ),
                             ),
                           ],
                         ),
@@ -384,65 +397,81 @@ class _InputBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(4, 0, 4, 4),
-      child: Stack(
-        clipBehavior: Clip.none,
+      child: Row(
         children: [
-          Row(
-            children: [
-              InkWell(
-                onTap: onTapMenu,
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  constraints: const BoxConstraints(minWidth: 40),
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFE5E7EB),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: const Icon(Icons.menu, color: Color(0xFF374151), size: 20),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-            child: TextField(
-              decoration: InputDecoration(
-                hintText: '메뉴 입력',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xFFE5E7EB), width: 1),
-                ),
-                contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                isDense: true,
-              ),
-              style: const TextStyle(fontSize: 14),
-              onChanged: onChanged,
-              onSubmitted: (_) => onAdd(),
-              textInputAction: TextInputAction.done,
-              controller: controller,
+          // 피그마: 햄버거 아이콘(회색), 배경 없음
+          InkWell(
+            onTap: onTapMenu,
+            borderRadius: BorderRadius.circular(12),
+            child: const SizedBox(
+              width: 40,
+              height: 40,
+              child: Icon(Icons.menu, color: Color(0xFF9CA3AF), size: 24),
             ),
           ),
           const SizedBox(width: 8),
+          Expanded(
+            child: SizedBox(
+              height: 40, // 버튼(minimumSize)의 height와 동일
+              child: TextField(
+                decoration: InputDecoration(
+                  hintText: '메뉴 입력',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1), // stone-300
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  isDense: true,
+                  suffixIconConstraints: const BoxConstraints.tightFor(width: 40, height: 40),
+                  // 피그마: 우측 동그란 X(입력 클리어)
+                  suffixIcon: controller.text.isEmpty
+                      ? null
+                      : Center(
+                          child: InkWell(
+                            onTap: () => onChanged(''),
+                            borderRadius: BorderRadius.circular(999),
+                            child: Container(
+                              width: 15,
+                              height: 15,
+                              decoration: const BoxDecoration(
+                                color: Color(0xFFA1A1A1), // neutral-400
+                                shape: BoxShape.circle,
+                              ),
+                              child: const Center(
+                                child: Icon(Icons.close, size: 10, color: Colors.white),
+                              ),
+                            ),
+                          ),
+                        ),
+                ),
+                style: const TextStyle(fontSize: 14),
+                onChanged: onChanged,
+                onSubmitted: (_) => onAdd(),
+                textInputAction: TextInputAction.done,
+                controller: controller,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
           ElevatedButton(
             onPressed: onAdd,
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFFE5E7EB),
+              backgroundColor: const Color(0xFFE5E7EB), // zinc-100
               foregroundColor: const Color(0xFF111827),
               elevation: 0,
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               minimumSize: const Size(60, 40),
             ),
-              child: const Text('입력', style: TextStyle(fontSize: 14)),
-          ),
-            ],
+            child: const Text('입력', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
           ),
         ],
       ),
@@ -486,7 +515,7 @@ class _MenuList extends StatelessWidget {
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                   decoration: BoxDecoration(
-                    color: const Color(0xFFFFF7ED), // orange-50
+                    color: const Color(0xFFFFF5F0), // orange-50
                     borderRadius: BorderRadius.circular(999),
                   ),
                   child: Row(
@@ -497,11 +526,19 @@ class _MenuList extends StatelessWidget {
                         style: const TextStyle(fontSize: 14, color: Color(0xFF1F2937)),
                       ),
                       const SizedBox(width: 8),
-                      GestureDetector(
+                      InkWell(
                         onTap: () => onRemove(i),
-                        child: const Text(
-                          '✕',
-                          style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
+                        borderRadius: BorderRadius.circular(999),
+                        child: Container(
+                          width: 15,
+                          height: 15,
+                          decoration: const BoxDecoration(
+                            color: Color(0xFFA1A1A1), // zinc-300
+                            shape: BoxShape.circle,
+                          ),
+                          child: const Center(
+                            child: Icon(Icons.close, size: 10, color: Colors.white),
+                          ),
                         ),
                       ),
                     ],

--- a/lib/features/admin/screens/admin_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_menu_edit_screen.dart
@@ -78,13 +78,7 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
     final days = List.generate(7, (i) => addDaysYmd(vm.mondayId, i));
 
     return WillPopScope(
-      onWillPop: () async {
-        final ok = await _confirmDiscardIfDirty(vm);
-        if (!ok) return false;
-        if (!context.mounted) return false;
-        Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu', (r) => false);
-        return false;
-      },
+      onWillPop: () => _confirmDiscardIfDirty(vm),
       child: Scaffold(
         appBar: AppBar(
           toolbarHeight: 48,
@@ -111,7 +105,7 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
               final ok = await _confirmDiscardIfDirty(vm);
               if (!ok) return;
               if (!context.mounted) return;
-              Navigator.of(context).pushNamedAndRemoveUntil('/admin/menu', (r) => false);
+              Navigator.of(context).maybePop();
             },
           ),
           actions: [
@@ -238,7 +232,7 @@ class _AdminMenuEditScreenState extends State<AdminMenuEditScreen> {
                                               children: [
                                                 Expanded(
                                                   child: Text(
-                                                    vm.frequentMenus[i].menu.join(', '),
+                                                    vm.frequentMenus[i].menus.join(', '),
                                                     style: const TextStyle(fontSize: 14, color: Color(0xFF374151)),
                                                     maxLines: 1,
                                                     overflow: TextOverflow.ellipsis,

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -70,22 +70,45 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
             child: TextButton(
               onPressed: () => Navigator.of(context).pushNamed('/admin/menu/frequent'),
               style: TextButton.styleFrom(
-                backgroundColor: const Color(0xFFF97316),
+                backgroundColor: const Color(0xFFFB923C), // orange-400
                 foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(50)),
                 minimumSize: Size.zero,
                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               ),
-              child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700)),
+              child: const Text('자주 쓰는 메뉴', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600, height: 1)),
             ),
           ),
         ],
       ),
       body: Container(
-        color: const Color(0xFFF5F6F7),
+        color: const Color(0xFFF7F7F7), // stone-50
         child: Column(
           children: [
+            if (vm.groups.length > 1)
+              Container(
+                width: double.infinity,
+                height: 48,
+                color: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      for (final g in vm.groups) ...[
+                        _GroupChip(
+                          label: g.name,
+                          selected: vm.selectedGroupId == g.id,
+                          onTap: () => context.read<AdminMenuViewModel>().selectGroup(g.id),
+                        ),
+                        const SizedBox(width: 8),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            if (vm.groups.length > 1) const Divider(height: 1, thickness: 1, color: Color(0xFFFAFAF9)),
             Expanded(
               child: vm.loading && vm.weeks.isEmpty
                   ? const Center(child: CircularProgressIndicator())
@@ -109,7 +132,7 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
                       child: ListView.builder(
                         controller: _scroll,
                         physics: const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics()),
-                        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                        padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
                         itemCount: vm.weeks.length + 1,
                         itemBuilder: (context, idx) {
                           if (idx == vm.weeks.length) {
@@ -130,10 +153,14 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
                             key: key,
                             child: _WeekCard(
                               week: week,
-                              onTapDay: (ymd) => Navigator.of(context).pushNamed(
-                                AdminMenuEditScreen.routeName,
-                                arguments: ymd,
-                              ),
+                              onTapDay: (ymd) {
+                                final groupId = vm.selectedGroupId;
+                                if (groupId == null) return;
+                                Navigator.of(context).pushNamed(
+                                  AdminMenuEditScreen.routeName,
+                                  arguments: {'date': ymd, 'groupId': groupId},
+                                );
+                              },
                             ),
                           );
                         },
@@ -155,6 +182,42 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
 
 }
 
+class _GroupChip extends StatelessWidget {
+  const _GroupChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(30),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFFFB923C) : const Color(0xFFF4F4F5), // orange-400 / zinc-100
+          borderRadius: BorderRadius.circular(30),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            height: 1,
+            color: selected ? Colors.white : const Color(0xFF27272A), // zinc-800
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _WeekCard extends StatelessWidget {
   final List<AdminMenuDay> week;
   final ValueChanged<String> onTapDay;
@@ -163,75 +226,147 @@ class _WeekCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: const [BoxShadow(color: Color(0x11000000), blurRadius: 10, offset: Offset(0, 4))],
-      ),
-      child: Column(
+    const line = Color(0xFFD9D9D9); // zinc-300 (figma)
+    final hairline = 1 / MediaQuery.of(context).devicePixelRatio;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 30),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (int i = 0; i < week.length; i++) ...[
-            _DayRow(day: week[i], onTap: () => onTapDay(week[i].id)),
-            if (i != week.length - 1) const Divider(height: 1, color: Color(0xFFE5E7EB)),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _DayRow extends StatelessWidget {
-  final AdminMenuDay day;
-  final VoidCallback onTap;
-
-  const _DayRow({required this.day, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final summary = day.items.isNotEmpty ? day.items.join(', ') : '메뉴 없음';
-    final opacity = day.isPast ? 0.4 : 1.0;
-
-    return Opacity(
-      opacity: opacity,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              SizedBox(
-                width: 64,
-                child: Text(
-                  day.dateLabel,
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: day.isToday ? FontWeight.w800 : FontWeight.w600,
-                    color: day.isToday ? const Color(0xFFF97316) : const Color(0xFF6B7280),
+          // left date column (w-12)
+          SizedBox(
+            width: 48,
+            child: Column(
+              children: [
+                for (int i = 0; i < week.length; i++)
+                  Opacity(
+                    opacity: week[i].isPast ? 0.4 : 1.0,
+                    child: Container(
+                      height: 48,
+                      alignment: Alignment.center,
+                      child: Text(
+                        week[i].dateLabel,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          color: week[i].isToday ? const Color(0xFFFB923C) : const Color(0xFF737373), // orange-400 / neutral-500
+                          fontSize: 14,
+                          fontWeight: week[i].isToday ? FontWeight.w600 : FontWeight.w400,
+                          height: 1,
+                        ),
+                      ),
+                    ),
                   ),
-                ),
-              ),
-              SizedBox(
-                width: 40,
-                child: Text(day.weekdayLabel, style: const TextStyle(fontSize: 13, color: Color(0xFF6B7280))),
-              ),
-              Expanded(
-                child: Text(
-                  summary,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 13,
-                    color: day.items.isNotEmpty ? const Color(0xFF111827) : const Color(0xFF9CA3AF),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 8),
-              const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 20),
-            ],
+              ],
+            ),
           ),
-        ),
+          const SizedBox(width: 10),
+          // right day/summary column (w-72)
+          Expanded(
+            child: Stack(
+              children: [
+                Column(
+                  children: [
+                    for (int i = 0; i < week.length; i++)
+                      Opacity(
+                        opacity: week[i].isPast ? 0.4 : 1.0,
+                        child: InkWell(
+                          onTap: () => onTapDay(week[i].id),
+                          borderRadius: BorderRadius.only(
+                            topLeft: Radius.circular(i == 0 ? 16 : 0),
+                            topRight: Radius.circular(i == 0 ? 16 : 0),
+                            bottomLeft: Radius.circular(i == week.length - 1 ? 16 : 0),
+                            bottomRight: Radius.circular(i == week.length - 1 ? 16 : 0),
+                          ),
+                          child: Container(
+                            height: 48,
+                            
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.only(
+                                topLeft: Radius.circular(i == 0 ? 16 : 0),
+                                topRight: Radius.circular(i == 0 ? 16 : 0),
+                                bottomLeft: Radius.circular(i == week.length - 1 ? 16 : 0),
+                                bottomRight: Radius.circular(i == week.length - 1 ? 16 : 0),
+                              ),
+                            ),
+                            child: Stack(
+                              children: [
+                                // bottom divider (except last)
+                                if (i != week.length - 1)
+                                  Positioned(
+                                    left: 0,
+                                    right: 0,
+                                    bottom: 0,
+                                    child: SizedBox(
+                                      height: hairline,
+                                      child: const DecoratedBox(decoration: BoxDecoration(color: line)),
+                                    ),
+                                  ),
+                                Row(
+                                  children: [
+                                    SizedBox(
+                                      width: 48,
+                                      child: Padding(
+                                        padding: const EdgeInsets.only(left: 19),
+                                        child: Align(
+                                          alignment: Alignment.centerLeft,
+                                          child: Text(
+                                            week[i].weekdayLabel,
+                                            style: const TextStyle(
+                                              color: Color(0xFF737373), // neutral-500
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.w400,
+                                              height: 1,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    SizedBox(width: hairline), // divider 공간(실선은 Stack이 그림)
+                                    Expanded(
+                                      child: Padding(
+                                        padding: const EdgeInsets.only(left: 12, right: 8),
+                                        child: Text(
+                                          week[i].items.isNotEmpty ? week[i].items.join(', ') : '',
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: TextStyle(
+                                            fontSize: 13,
+                                            height: 1,
+                                            color: week[i].items.isNotEmpty ? const Color(0xFF111827) : const Color(0xFF9CA3AF),
+                                            fontWeight: FontWeight.w400,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    const Padding(
+                                      padding: EdgeInsets.only(right: 10),
+                                      child: Icon(Icons.chevron_right, color: Color(0xFFA3A3A3), size: 20),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                // ✅ 요일(48px) ↔ 메뉴 영역 사이 세로 구분선 (전체 높이)
+                Positioned(
+                  left: 48,
+                  top: 0,
+                  bottom: 0,
+                  child: SizedBox(
+                    width: hairline,
+                    child: const DecoratedBox(decoration: BoxDecoration(color: line)),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -53,14 +53,8 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
   Widget build(BuildContext context) {
     final vm = context.watch<AdminMenuViewModel>();
 
-    return WillPopScope(
-      onWillPop: () async {
-        if (!mounted) return true;
-        Navigator.of(context).pushNamedAndRemoveUntil('/admin', (r) => false);
-        return false;
-      },
-      child: Scaffold(
-        appBar: AppBar(
+    return Scaffold(
+      appBar: AppBar(
         toolbarHeight: 48,
         backgroundColor: Colors.white,
         elevation: 0,
@@ -68,7 +62,7 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
-          onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil('/admin', (r) => false),
+          onPressed: () => Navigator.of(context).maybePop(),
         ),
         actions: [
           Padding(
@@ -87,8 +81,8 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
             ),
           ),
         ],
-        ),
-        body: Container(
+      ),
+      body: Container(
         color: const Color(0xFFF7F7F7), // stone-50
         child: Column(
           children: [
@@ -182,7 +176,6 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
               ),
           ],
         ),
-      ),
       ),
     );
   }

--- a/lib/features/admin/screens/admin_menu_screen.dart
+++ b/lib/features/admin/screens/admin_menu_screen.dart
@@ -53,8 +53,14 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
   Widget build(BuildContext context) {
     final vm = context.watch<AdminMenuViewModel>();
 
-    return Scaffold(
-      appBar: AppBar(
+    return WillPopScope(
+      onWillPop: () async {
+        if (!mounted) return true;
+        Navigator.of(context).pushNamedAndRemoveUntil('/admin', (r) => false);
+        return false;
+      },
+      child: Scaffold(
+        appBar: AppBar(
         toolbarHeight: 48,
         backgroundColor: Colors.white,
         elevation: 0,
@@ -81,8 +87,8 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
             ),
           ),
         ],
-      ),
-      body: Container(
+        ),
+        body: Container(
         color: const Color(0xFFF7F7F7), // stone-50
         child: Column(
           children: [
@@ -176,6 +182,7 @@ class _AdminMenuScreenState extends State<AdminMenuScreen> {
               ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/lib/features/admin/screens/admin_settings_screen.dart
+++ b/lib/features/admin/screens/admin_settings_screen.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auth/screens/find_account_screen.dart';
+import '../../auth/screens/login_screen.dart';
+import '../../mypage/screens/change_email_screen.dart';
+import '../../mypage/viewmodels/mypage_view_model.dart';
+
+class AdminSettingsScreen extends StatelessWidget {
+  static const routeName = '/admin/settings';
+
+  const AdminSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<MyPageViewModel>();
+    final disabled = vm.loading;
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        centerTitle: true,
+        title: const Text(
+          '설정',
+          style: TextStyle(
+            color: Color(0xFF111827),
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF111827)),
+          onPressed: disabled ? null : () => Navigator.of(context).maybePop(),
+        ),
+      ),
+      body: Column(
+        children: [
+          _SettingsItem(
+            label: '회원정보 수정',
+            onTap: disabled ? null : () => Navigator.of(context).pushNamed(ChangeEmailScreen.routeName),
+          ),
+          const Divider(height: 1, color: Color(0xFFE5E7EB)),
+          _SettingsItem(
+            label: '비밀번호 변경',
+            onTap: disabled ? null : () => Navigator.of(context).pushNamed(FindAccountScreen.routeName, arguments: 'pw'),
+          ),
+          const Divider(height: 1, color: Color(0xFFE5E7EB)),
+          _SettingsItem(
+            label: '로그아웃',
+            onTap: disabled
+                ? null
+                : () async {
+                    await vm.logout();
+                    if (!context.mounted) return;
+                    Navigator.of(context).pushNamedAndRemoveUntil('/', (r) => false, arguments: 3);
+                  },
+          ),
+          const Divider(height: 1, color: Color(0xFFE5E7EB)),
+          _SettingsItem(
+            label: '회원탈퇴',
+            labelColor: const Color(0xFFEF4444),
+            onTap: disabled
+                ? null
+                : () async {
+                    final ok = await showDialog<bool>(
+                      context: context,
+                      builder: (_) => const _DeleteAccountDialog(),
+                    );
+                    if (ok != true) return;
+                    final success = await vm.deleteAccount();
+                    if (!context.mounted) return;
+                    if (success) {
+                      Navigator.of(context).pushNamedAndRemoveUntil(LoginScreen.routeName, (r) => false);
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(vm.errorMessage ?? '회원 탈퇴에 실패했습니다. 다시 시도해주세요.')),
+                      );
+                    }
+                  },
+          ),
+          const Divider(height: 1, color: Color(0xFFE5E7EB)),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsItem extends StatelessWidget {
+  final String label;
+  final VoidCallback? onTap;
+  final Color? labelColor;
+
+  const _SettingsItem({required this.label, required this.onTap, this.labelColor});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: TextStyle(fontSize: 14, color: labelColor ?? const Color(0xFF111827)),
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: Color(0xFF9CA3AF), size: 22),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DeleteAccountDialog extends StatelessWidget {
+  const _DeleteAccountDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: const Text(
+        '탈퇴하면 모든 기록이 사라집니다\n정말 탈퇴하시겠습니까?',
+        textAlign: TextAlign.center,
+        style: TextStyle(height: 1.4),
+      ),
+      actionsPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      actions: [
+        Row(
+          children: [
+            Expanded(
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                style: TextButton.styleFrom(
+                  backgroundColor: const Color(0xFFF3F4F6),
+                  foregroundColor: const Color(0xFF6B7280),
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                child: const Text('취소'),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                style: TextButton.styleFrom(
+                  backgroundColor: const Color(0xFFEF4444),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                child: const Text('탈퇴'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+

--- a/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
@@ -28,7 +28,7 @@ class AdminFrequentMenuEditViewModel extends ChangeNotifier {
     try {
       final res = await _repo.getFavoriteGroup(groupId: groupId!);
       if (res.groups.isNotEmpty) {
-        menus = List<String>.from(res.groups.first.menu);
+        menus = List<String>.from(res.groups.first.menus);
       }
     } catch (e) {
       if (e is ApiException) {

--- a/lib/features/admin/viewmodels/admin_frequent_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_frequent_menu_view_model.dart
@@ -39,7 +39,7 @@ class AdminFrequentMenuViewModel extends ChangeNotifier {
     notifyListeners();
     try {
       await _repo.deleteFavorites(groupIds: groupIds);
-      groups = groups.where((g) => !groupIds.contains(g.groupId)).toList();
+      groups = groups.where((g) => !groupIds.contains(g.id)).toList();
     } catch (e) {
       if (e is ApiException) {
         errorMessage = mapErrorToMessage(e, responseData: e.details);

--- a/lib/features/admin/viewmodels/admin_inventory_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_inventory_view_model.dart
@@ -18,12 +18,34 @@ class AdminInventoryViewModel extends ChangeNotifier {
   String date = kstTodayYmd(); // YYYY-MM-DD (KST fixed)
 
   DailyMenuResponse? daily;
-  int stock = 0;
   bool open = false;
 
   bool showOpenModal = false;
   bool showCloseModal = false;
-  int _lastSavedStock = 0;
+
+  // groupId -> current stock (editable)
+  final Map<int, int> _groupStocks = <int, int>{};
+  int _lastSavedTotalStock = 0;
+
+  List<DailyMenuGroupItem> get groupsSorted {
+    final groups = daily?.groups ?? const <DailyMenuGroupItem>[];
+    final sorted = [...groups]..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    return sorted;
+  }
+
+  int get totalStock {
+    if (_groupStocks.isNotEmpty) {
+      return _groupStocks.values.fold<int>(0, (sum, v) => sum + v);
+    }
+    return daily?.totalStock ?? 0;
+  }
+
+  int groupStock(int groupId) {
+    final v = _groupStocks[groupId];
+    if (v != null) return v;
+    final g = (daily?.groups ?? const <DailyMenuGroupItem>[]).where((e) => e.id == groupId).cast<DailyMenuGroupItem?>().firstWhere((_) => true, orElse: () => null);
+    return g?.stock ?? 0;
+  }
 
   Future<void> loadToday() async {
     loading = true;
@@ -33,10 +55,11 @@ class AdminInventoryViewModel extends ChangeNotifier {
     try {
       final res = await _repo.getDailyMenu(date: date);
       daily = res;
-      // group 기반 응답에서는 totalStock으로 노출 (Unit E에서 그룹별 재고 UI로 전환 예정)
-      stock = res?.totalStock ?? 0;
       open = res?.open ?? false;
-      _lastSavedStock = stock;
+      _groupStocks
+        ..clear()
+        ..addEntries((res?.groups ?? const <DailyMenuGroupItem>[]).map((g) => MapEntry(g.id, g.stock)));
+      _lastSavedTotalStock = totalStock;
     } catch (e) {
       if (e is ApiException) {
         errorMessage = mapErrorToMessage(e, responseData: e.details);
@@ -98,43 +121,84 @@ class AdminInventoryViewModel extends ChangeNotifier {
   }
 
   Future<void> adjustStock(int delta) async {
+    // legacy: no-op (group 기반으로 전환됨)
+  }
+
+  Future<void> adjustGroupStock(int groupId, int delta) async {
     if (!open) {
       showOpenModal = true;
       notifyListeners();
       return;
     }
-    final next = (stock + delta).clamp(0, 1 << 30);
-    stock = next;
+    final next = (groupStock(groupId) + delta).clamp(0, 1 << 30);
+    _groupStocks[groupId] = next;
     notifyListeners();
-    await commitStock();
+    await commitGroupStock(groupId);
   }
 
-  void setStockFromInput(String raw) {
+  void setGroupStockFromInput(int groupId, String raw) {
     final parsed = int.tryParse(raw.trim()) ?? 0;
-    stock = parsed < 0 ? 0 : parsed;
+    _groupStocks[groupId] = parsed < 0 ? 0 : parsed;
     notifyListeners();
   }
 
-  Future<void> commitStock() async {
+  Future<void> commitGroupStock(int groupId) async {
     if (!open) return;
-    final menuId = daily?.id;
-    if (menuId == null) return;
+    final stock = _groupStocks[groupId] ?? 0;
 
     saving = true;
     errorMessage = null;
     notifyListeners();
     try {
-      await _repo.updateDailyStock(menuId: menuId, stock: stock);
-      // 영업 중 상태에서 재고가 0으로 떨어졌을 때, 영업 종료 전환 모달 제안
-      if (open && stock == 0 && _lastSavedStock > 0) {
+      await _repo.updateMenuGroupStock(groupId: groupId, stock: stock);
+      final nextTotal = totalStock;
+      // 영업 중 상태에서 총 재고가 0으로 떨어졌을 때, 영업 종료 전환 모달 제안
+      if (open && nextTotal == 0 && _lastSavedTotalStock > 0) {
         showCloseModal = true;
       }
-      _lastSavedStock = stock;
+      _lastSavedTotalStock = nextTotal;
     } catch (e) {
       if (e is ApiException) {
         errorMessage = mapErrorToMessage(e, responseData: e.details);
       } else {
         errorMessage = '재고 업데이트 실패';
+      }
+    } finally {
+      saving = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> deductGroupStock(int groupId, DeductionUnit unit) async {
+    if (!open) {
+      showOpenModal = true;
+      notifyListeners();
+      return;
+    }
+    final current = groupStock(groupId);
+    final delta = switch (unit) {
+      DeductionUnit.single => 1,
+      DeductionUnit.multiFive => 5,
+      DeductionUnit.multiTen => 10,
+    };
+    if (current < delta) return;
+    saving = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      final res = await _repo.deductMenuGroupStock(groupId: groupId, deductionUnit: unit);
+      final nextStock = (res['stock'] is int) ? res['stock'] as int : int.tryParse('${res['stock']}') ?? groupStock(groupId);
+      _groupStocks[groupId] = nextStock < 0 ? 0 : nextStock;
+      final nextTotal = totalStock;
+      if (open && nextTotal == 0 && _lastSavedTotalStock > 0) {
+        showCloseModal = true;
+      }
+      _lastSavedTotalStock = nextTotal;
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '재고 차감 실패';
       }
     } finally {
       saving = false;

--- a/lib/features/admin/viewmodels/admin_inventory_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_inventory_view_model.dart
@@ -33,7 +33,8 @@ class AdminInventoryViewModel extends ChangeNotifier {
     try {
       final res = await _repo.getDailyMenu(date: date);
       daily = res;
-      stock = res?.stock ?? 0;
+      // group 기반 응답에서는 totalStock으로 노출 (Unit E에서 그룹별 재고 UI로 전환 예정)
+      stock = res?.totalStock ?? 0;
       open = res?.open ?? false;
       _lastSavedStock = stock;
     } catch (e) {

--- a/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
@@ -8,11 +8,17 @@ import '../models/menu_models.dart';
 import '../repositories/admin_repository.dart';
 
 class AdminMenuEditViewModel extends ChangeNotifier {
-  AdminMenuEditViewModel(this._repo, {String? initialDate})
-      : selectedId = initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd(),
+  AdminMenuEditViewModel(
+    this._repo, {
+    String? initialDate,
+    required this.groupId,
+  })  :
+        selectedId = initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd(),
         mondayId = mondayOfYmd(initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd());
 
   final AdminRepository _repo;
+
+  final int? groupId;
 
   String selectedId; // YYYY-MM-DD
   String mondayId; // YYYY-MM-DD (monday)
@@ -24,19 +30,30 @@ class AdminMenuEditViewModel extends ChangeNotifier {
   String? errorMessage;
 
   List<String> menus = [];
+  String groupName = '';
 
   bool showSavedToast = false;
   bool showFrequentMenu = false;
   List<FavoriteGroup> frequentMenus = [];
 
   Future<void> load() async {
+    if (groupId == null) {
+      menus = [];
+      groupName = '';
+      dirty = false;
+      loading = false;
+      notifyListeners();
+      return;
+    }
     loading = true;
     errorMessage = null;
     notifyListeners();
     try {
       final res = await _repo.getDailyMenu(date: selectedId);
-      // 임시 호환: group 기반 응답을 "메뉴 문자열 리스트"로 편집 UI에 바인딩.
-      menus = res?.flattenedMenus ?? <String>[];
+      final groups = res?.groups ?? const <DailyMenuGroupItem>[];
+      final group = groups.where((g) => g.id == groupId).cast<DailyMenuGroupItem?>().firstWhere((_) => true, orElse: () => null);
+      menus = group?.menus ?? <String>[];
+      groupName = group?.name ?? '';
       dirty = false;
     } catch (e) {
       if (e is ApiException) {
@@ -74,12 +91,13 @@ class AdminMenuEditViewModel extends ChangeNotifier {
   }
 
   Future<void> save() async {
+    if (groupId == null) return;
     if (saving) return;
     saving = true;
     errorMessage = null;
     notifyListeners();
     try {
-      await _repo.saveDailyMenu(date: selectedId, menus: menus);
+      await _repo.upsertMenuGroupMenus(groupId: groupId!, date: selectedId, menus: menus);
       dirty = false;
       showSavedToast = true;
     } catch (e) {

--- a/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
@@ -155,7 +155,7 @@ class AdminMenuEditViewModel extends ChangeNotifier {
   }
 
   void selectFrequentMenu(FavoriteGroup group) {
-    menus = [...menus, ...group.menu];
+    menus = [...menus, ...group.menus];
     dirty = true;
     showFrequentMenu = false;
     notifyListeners();

--- a/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
@@ -35,7 +35,8 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     notifyListeners();
     try {
       final res = await _repo.getDailyMenu(date: selectedId);
-      menus = res?.menus ?? <String>[];
+      // 임시 호환: group 기반 응답을 "메뉴 문자열 리스트"로 편집 UI에 바인딩.
+      menus = res?.flattenedMenus ?? <String>[];
       dirty = false;
     } catch (e) {
       if (e is ApiException) {

--- a/lib/features/admin/viewmodels/admin_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_view_model.dart
@@ -16,11 +16,16 @@ class AdminMenuViewModel extends ChangeNotifier {
   bool loading = false;
   bool loadingNext = false;
   bool loadingPrev = false;
+  bool loadingGroups = false;
   String? errorMessage;
+
+  List<DailyMenuGroupItem> groups = [];
+  int? selectedGroupId;
 
   /// weeks[0] is the top-most week.
   final List<List<AdminMenuDay>> weeks = [];
   final Set<String> _loadedMondays = <String>{};
+  final Map<String, List<WeeklyMenuDay>> _rawWeeksByMonday = <String, List<WeeklyMenuDay>>{};
 
   String todayYmd = kstTodayYmd();
 
@@ -30,6 +35,7 @@ class AdminMenuViewModel extends ChangeNotifier {
     errorMessage = null;
     notifyListeners();
     try {
+      await _loadGroupsIfNeeded();
       final monday = mondayOfYmd(todayYmd);
       // 초기 4주를 로드해서 충분한 스크롤/무한로딩 UX를 확보한다.
       await _loadWeek(baseDate: monday, direction: 'next', force: true);
@@ -46,6 +52,87 @@ class AdminMenuViewModel extends ChangeNotifier {
       loading = false;
       notifyListeners();
     }
+  }
+
+  Future<void> jumpToWeek({required String dateYmd}) async {
+    loading = true;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      await _loadGroupsIfNeeded();
+      final monday = mondayOfYmd(dateYmd);
+
+      // 멀리 점프 시에는 현재 캐시/리스트를 초기화하고 해당 주 기준으로 재구성한다.
+      weeks.clear();
+      _loadedMondays.clear();
+      _rawWeeksByMonday.clear();
+
+      await _loadWeek(baseDate: monday, direction: 'next', force: true);
+      await _loadWeek(baseDate: addWeeksYmd(monday, 1), direction: 'next', force: true);
+      await _loadWeek(baseDate: addWeeksYmd(monday, 2), direction: 'next', force: true);
+      await _loadWeek(baseDate: addWeeksYmd(monday, 3), direction: 'next', force: true);
+    } catch (e) {
+      if (e is ApiException) {
+        errorMessage = mapErrorToMessage(e, responseData: e.details);
+      } else {
+        errorMessage = '주간 메뉴 불러오기 실패';
+      }
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadGroupsIfNeeded() async {
+    if (groups.isNotEmpty && selectedGroupId != null) return;
+    loadingGroups = true;
+    notifyListeners();
+    try {
+      final res = await _repo.getDailyMenu(date: todayYmd);
+      final list = res?.groups ?? const <DailyMenuGroupItem>[];
+      groups = list;
+      if (list.isNotEmpty) {
+        if (selectedGroupId == null || !list.any((g) => g.id == selectedGroupId)) {
+          selectedGroupId = list.first.id;
+        }
+      } else {
+        selectedGroupId = null;
+      }
+    } finally {
+      loadingGroups = false;
+      notifyListeners();
+    }
+  }
+
+  void selectGroup(int groupId) {
+    if (selectedGroupId == groupId) return;
+    selectedGroupId = groupId;
+    // 이미 로드된 주차는 raw cache로 즉시 재매핑한다 (웹 useWeeklyMenus와 동일).
+    _remapWeeksFromRaw();
+    notifyListeners();
+  }
+
+  void _remapWeeksFromRaw() {
+    if (weeks.isEmpty) return;
+    final rebuilt = <List<AdminMenuDay>>[];
+    for (final week in weeks) {
+      final monday = mondayOfYmd(week.first.id);
+      final raw = _rawWeeksByMonday[monday];
+      if (raw == null || raw.isEmpty) {
+        rebuilt.add(week);
+      } else {
+        final res = WeeklyMenuResponse(
+          storeId: 0,
+          startDate: '',
+          endDate: '',
+          dailyMenus: raw,
+        );
+        rebuilt.add(_buildWeekFromApiOrEmpty(res, monday));
+      }
+    }
+    weeks
+      ..clear()
+      ..addAll(rebuilt);
   }
 
   Future<void> loadNextWeek() async {
@@ -108,6 +195,7 @@ class AdminMenuViewModel extends ChangeNotifier {
     }
 
     final res = await _repo.getWeeklyMenu(date: baseDate);
+    _rawWeeksByMonday[monday] = res.dailyMenus;
     final week = _buildWeekFromApiOrEmpty(res, monday);
     if (direction == 'next') {
       weeks.add(week);
@@ -133,8 +221,9 @@ class AdminMenuViewModel extends ChangeNotifier {
       final weekdayLabel = weekdayLabels[(dt.weekday - 1).clamp(0, 6)];
 
       final api = map[ymd];
-      // 임시 호환: group 기반 응답을 "메뉴 문자열 리스트"로 평탄화하여 주간 카드에 노출.
-      final items = api?.flattenedMenus ?? <String>[];
+      // 웹(useWeeklyMenus)과 동일: groupId가 있으면 해당 그룹, 없으면 첫 그룹.
+      final g = _pickGroupForDay(api?.groups ?? const <WeeklyDayGroup>[], selectedGroupId);
+      final items = g?.menus ?? <String>[];
 
       final isPast = dt.isBefore(_parseYmdLocal(todayYmd));
       final isToday = ymd == todayYmd;
@@ -158,5 +247,11 @@ class AdminMenuViewModel extends ChangeNotifier {
     return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
   }
 
+  WeeklyDayGroup? _pickGroupForDay(List<WeeklyDayGroup> groups, int? groupId) {
+    if (groups.isEmpty) return null;
+    if (groupId == null) return groups.first;
+    final hit = groups.where((g) => g.groupId == groupId).cast<WeeklyDayGroup?>().firstWhere((_) => true, orElse: () => null);
+    return hit ?? groups.first;
+  }
 }
 

--- a/lib/features/admin/viewmodels/admin_menu_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_view_model.dart
@@ -133,7 +133,8 @@ class AdminMenuViewModel extends ChangeNotifier {
       final weekdayLabel = weekdayLabels[(dt.weekday - 1).clamp(0, 6)];
 
       final api = map[ymd];
-      final items = api?.menus ?? <String>[];
+      // 임시 호환: group 기반 응답을 "메뉴 문자열 리스트"로 평탄화하여 주간 카드에 노출.
+      final items = api?.flattenedMenus ?? <String>[];
 
       final isPast = dt.isBefore(_parseYmdLocal(todayYmd));
       final isToday = ymd == todayYmd;

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -20,7 +20,15 @@ class LoginScreen extends StatelessWidget {
         title: const Text(''),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).pushReplacementNamed('/'),
+          onPressed: () {
+            final nav = Navigator.of(context);
+            // 로그인 화면이 initialRoute로 열린 경우(스택에 이전 화면 없음)에는 pop이 불가능하므로 홈으로 fallback
+            if (nav.canPop()) {
+              nav.pop();
+            } else {
+              nav.pushReplacementNamed('/');
+            }
+          },
         ),
       ),
       body: SafeArea(

--- a/lib/features/store/models/store_models.dart
+++ b/lib/features/store/models/store_models.dart
@@ -5,6 +5,7 @@ class StoreListItem {
   final List<String> menus;
   final int remain;
   final bool? open;
+  final TodayMenu? todayMenu;
 
   StoreListItem({
     required this.id,
@@ -13,7 +14,29 @@ class StoreListItem {
     required this.menus,
     required this.remain,
     this.open,
+    required this.todayMenu,
   });
+
+  List<TodayMenuGroup> get menuGroups => todayMenu?.menuGroups ?? const <TodayMenuGroup>[];
+  bool get hasMultiGroups => menuGroups.length >= 2;
+
+  /// 단일 그룹일 때 기존 카드 레이아웃에 쓰는 메뉴 텍스트
+  String get singleGroupMenusText {
+    final g = menuGroups.isNotEmpty ? (menuGroups..sort((a, b) => a.sortOrder.compareTo(b.sortOrder))).first : null;
+    if (g == null) {
+      if (menus.isEmpty) return '메뉴 정보 없음';
+      return menus.join(', ');
+    }
+    if (g.menus.isEmpty) return '메뉴 정보 없음';
+    return g.menus.map((e) => e.name).join(', ');
+  }
+
+  /// 단일 그룹일 때 재고 숫자 (없으면 remain fallback)
+  int get firstGroupStock {
+    if (menuGroups.isEmpty) return remain;
+    final sorted = [...menuGroups]..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    return sorted.first.stock;
+  }
 
   factory StoreListItem.fromJson(Map<String, dynamic> json) {
     int toInt(dynamic v, {int fallback = 0}) =>
@@ -51,9 +74,19 @@ class StoreListItem {
         ? (todayMenu['menus'] ?? todayMenu['menuNames'] ?? todayMenu['menu'])
         : (json['menus'] ?? json['menuNames']);
 
-    final remain = todayMenu is Map<String, dynamic>
-        ? (todayMenu['remain'] ?? todayMenu['stock'] ?? todayMenu['count'])
-        : (json['remain'] ?? json['stock'] ?? json['count']);
+    int? remainFromGroups;
+    TodayMenu? parsedTodayMenu;
+    if (todayMenu is Map<String, dynamic>) {
+      parsedTodayMenu = TodayMenu.fromJson(todayMenu);
+      if (parsedTodayMenu.menuGroups.isNotEmpty) {
+        remainFromGroups = parsedTodayMenu.menuGroups.fold<int>(0, (sum, g) => sum + g.stock);
+      }
+    }
+
+    final remain = remainFromGroups ??
+        (todayMenu is Map<String, dynamic>
+            ? (todayMenu['remain'] ?? todayMenu['stock'] ?? todayMenu['count'])
+            : (json['remain'] ?? json['stock'] ?? json['count']));
 
     return StoreListItem(
       id: toInt(json['id'] ?? json['storeId']),
@@ -67,6 +100,102 @@ class StoreListItem {
       menus: toStringList(menus),
       remain: toInt(remain, fallback: 0),
       open: toBool(json['open'] ?? json['isOpen']),
+      todayMenu: parsedTodayMenu,
+    );
+  }
+}
+
+class TodayMenuMenuItem {
+  final int id;
+  final String name;
+
+  TodayMenuMenuItem({required this.id, required this.name});
+
+  factory TodayMenuMenuItem.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    return TodayMenuMenuItem(
+      id: toInt(json['id']),
+      name: (json['name'] ?? '').toString(),
+    );
+  }
+}
+
+class TodayMenuGroup {
+  final int id;
+  final String name;
+  final int sortOrder;
+  final int capacity;
+  final int stock;
+  final List<TodayMenuMenuItem> menus;
+
+  TodayMenuGroup({
+    required this.id,
+    required this.name,
+    required this.sortOrder,
+    required this.capacity,
+    required this.stock,
+    required this.menus,
+  });
+
+  factory TodayMenuGroup.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    final rawMenus = json['menus'];
+    final menus = rawMenus is List
+        ? rawMenus
+            .whereType<Map>()
+            .map((e) => TodayMenuMenuItem.fromJson(e.cast<String, dynamic>()))
+            .toList(growable: false)
+        : <TodayMenuMenuItem>[];
+    return TodayMenuGroup(
+      id: toInt(json['id']),
+      name: (json['name'] ?? '').toString(),
+      sortOrder: toInt(json['sortOrder']),
+      capacity: toInt(json['capacity']),
+      stock: toInt(json['stock']),
+      menus: menus,
+    );
+  }
+}
+
+class TodayMenu {
+  final int id;
+  final String date; // YYYY-MM-DD
+  final String dayOfWeek; // MONDAY, ...
+  final List<TodayMenuGroup> menuGroups;
+  final bool open;
+  final bool? holiday;
+
+  TodayMenu({
+    required this.id,
+    required this.date,
+    required this.dayOfWeek,
+    required this.menuGroups,
+    required this.open,
+    required this.holiday,
+  });
+
+  factory TodayMenu.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    bool toBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is num) return v != 0;
+      final s = v?.toString().trim().toLowerCase();
+      if (s == null || s.isEmpty) return false;
+      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+    }
+
+    final rawGroups = json['menuGroups'];
+    final groups = rawGroups is List
+        ? rawGroups.whereType<Map>().map((e) => TodayMenuGroup.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <TodayMenuGroup>[];
+
+    return TodayMenu(
+      id: toInt(json['id']),
+      date: (json['date'] ?? '').toString(),
+      dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
+      menuGroups: groups,
+      open: toBool(json['open']),
+      holiday: json.containsKey('holiday') ? toBool(json['holiday']) : null,
     );
   }
 }

--- a/lib/features/store/models/store_models.dart
+++ b/lib/features/store/models/store_models.dart
@@ -207,7 +207,9 @@ class StoreDetail {
   final String? imageUrl;
   final String? address;
   final String? phone;
-  final List<String> menus;
+  final String? hours;
+  final int? remain;
+  final WeeklyMenuResponse? weeklyMenuResponse;
 
   StoreDetail({
     required this.id,
@@ -216,7 +218,9 @@ class StoreDetail {
     this.imageUrl,
     this.address,
     this.phone,
-    required this.menus,
+    this.hours,
+    this.remain,
+    required this.weeklyMenuResponse,
   });
 
   factory StoreDetail.fromJson(Map<String, dynamic> json) {
@@ -233,28 +237,6 @@ class StoreDetail {
       return null;
     }
 
-    List<String> toStringList(dynamic v) {
-      if (v is List) {
-        return v
-            .map((e) => e.toString())
-            .where((e) => e.trim().isNotEmpty)
-            .toList();
-      }
-      if (v is String && v.trim().isNotEmpty) {
-        return v
-            .split(',')
-            .map((e) => e.trim())
-            .where((e) => e.isNotEmpty)
-            .toList();
-      }
-      return [];
-    }
-
-    final todayMenu = json['todayMenu'];
-    final menus = todayMenu is Map<String, dynamic>
-        ? (todayMenu['menus'] ?? todayMenu['menuNames'] ?? todayMenu['menu'])
-        : (json['menus'] ?? json['menuNames']);
-
     return StoreDetail(
       id: toInt(json['id'] ?? json['storeId']),
       name: (json['name'] ?? json['storeName'] ?? '').toString(),
@@ -267,7 +249,118 @@ class StoreDetail {
               ?.toString(),
       address: json['address']?.toString(),
       phone: json['phone']?.toString(),
-      menus: toStringList(menus),
+      hours: json['hours']?.toString(),
+      remain: json['remain'] == null ? null : toInt(json['remain']),
+      weeklyMenuResponse: (json['weeklyMenuResponse'] is Map<String, dynamic>)
+          ? WeeklyMenuResponse.fromJson(json['weeklyMenuResponse'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+class StoreDetailDayGroup {
+  final int groupId;
+  final String name;
+  final int sortOrder;
+  final int stock;
+  final int capacity;
+  final List<String> menus;
+
+  StoreDetailDayGroup({
+    required this.groupId,
+    required this.name,
+    required this.sortOrder,
+    required this.stock,
+    required this.capacity,
+    required this.menus,
+  });
+
+  factory StoreDetailDayGroup.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    final rawMenus = json['menus'];
+    final menus = rawMenus is List ? rawMenus.map((e) => e.toString()).toList(growable: false) : <String>[];
+    return StoreDetailDayGroup(
+      groupId: toInt(json['groupId']),
+      name: (json['name'] ?? '').toString(),
+      sortOrder: toInt(json['sortOrder']),
+      stock: toInt(json['stock']),
+      capacity: toInt(json['capacity']),
+      menus: menus,
+    );
+  }
+}
+
+class StoreWeeklyMenuDay {
+  final int id;
+  final String date; // YYYY-MM-DD
+  final String dayOfWeek; // MONDAY, ...
+  final bool? holiday;
+  final int? totalStock;
+  final List<StoreDetailDayGroup> groups;
+  final bool open;
+
+  StoreWeeklyMenuDay({
+    required this.id,
+    required this.date,
+    required this.dayOfWeek,
+    required this.holiday,
+    required this.totalStock,
+    required this.groups,
+    required this.open,
+  });
+
+  factory StoreWeeklyMenuDay.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    bool toBool(dynamic v) {
+      if (v is bool) return v;
+      if (v is num) return v != 0;
+      final s = v?.toString().trim().toLowerCase();
+      if (s == null || s.isEmpty) return false;
+      return s == 'true' || s == '1' || s == 'y' || s == 'yes';
+    }
+
+    final rawGroups = json['groups'];
+    final groups = rawGroups is List
+        ? rawGroups.whereType<Map>().map((e) => StoreDetailDayGroup.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <StoreDetailDayGroup>[];
+
+    return StoreWeeklyMenuDay(
+      id: toInt(json['id']),
+      date: (json['date'] ?? '').toString(),
+      dayOfWeek: (json['dayOfWeek'] ?? '').toString(),
+      holiday: json.containsKey('holiday') ? toBool(json['holiday']) : null,
+      totalStock: json['totalStock'] == null ? null : toInt(json['totalStock']),
+      groups: groups,
+      open: toBool(json['open']),
+    );
+  }
+}
+
+class WeeklyMenuResponse {
+  final int storeId;
+  final String startDate;
+  final String endDate;
+  final List<StoreWeeklyMenuDay> dailyMenus;
+
+  WeeklyMenuResponse({
+    required this.storeId,
+    required this.startDate,
+    required this.endDate,
+    required this.dailyMenus,
+  });
+
+  factory WeeklyMenuResponse.fromJson(Map<String, dynamic> json) {
+    int toInt(dynamic v) => v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
+    final list = json['dailyMenus'];
+    final daily = list is List
+        ? list.whereType<Map>().map((e) => StoreWeeklyMenuDay.fromJson(e.cast<String, dynamic>())).toList(growable: false)
+        : <StoreWeeklyMenuDay>[];
+
+    return WeeklyMenuResponse(
+      storeId: toInt(json['storeId']),
+      startDate: (json['startDate'] ?? '').toString(),
+      endDate: (json['endDate'] ?? '').toString(),
+      dailyMenus: daily,
     );
   }
 }

--- a/lib/features/store/screens/store_detail_screen.dart
+++ b/lib/features/store/screens/store_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../common/utils/kst_date.dart';
 import '../models/store_models.dart';
 import '../repositories/store_repository.dart';
 import '../viewmodels/store_detail_view_model.dart';
@@ -156,23 +157,7 @@ class _StoreDetailView extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Text(
-                  '일주일 메뉴',
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
-                ),
-                const SizedBox(height: 10),
-                SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: Row(
-                    children: _weekdayDates(DateTime.now()).map((date) {
-                      return WeeklyMenuCard(
-                        dateLabel: _formatDateLabel(date),
-                        dayLabel: _weekdayLabel(date.weekday),
-                        items: detail.menus,
-                      );
-                    }).toList(),
-                  ),
-                ),
+                _WeeklyMenuSection(detail: detail, onReload: vm.load),
                 const SizedBox(height: 20),
                 const Text(
                   '다른 매장 보기',
@@ -186,39 +171,6 @@ class _StoreDetailView extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  String _weekdayLabel(int weekday) {
-    switch (weekday) {
-      case DateTime.monday:
-        return '월요일';
-      case DateTime.tuesday:
-        return '화요일';
-      case DateTime.wednesday:
-        return '수요일';
-      case DateTime.thursday:
-        return '목요일';
-      case DateTime.friday:
-        return '금요일';
-      case DateTime.saturday:
-        return '토요일';
-      case DateTime.sunday:
-        return '일요일';
-      default:
-        return '';
-    }
-  }
-
-  String _formatDateLabel(DateTime date) {
-    String two(int v) => v.toString().padLeft(2, '0');
-    return '${two(date.month)}월 ${two(date.day)}일';
-  }
-
-  List<DateTime> _weekdayDates(DateTime today) {
-    final startOfWeek = today.subtract(
-      Duration(days: today.weekday - DateTime.monday),
-    );
-    return List.generate(5, (i) => startOfWeek.add(Duration(days: i)));
   }
 
   Widget _buildOtherStores(BuildContext context, StoreDetailViewModel vm) {
@@ -309,5 +261,253 @@ class _StoreDetailView extends StatelessWidget {
         style: TextStyle(fontSize: 11, color: Color(0xFF9CA3AF)),
       ),
     );
+  }
+}
+
+class _WeeklyMenuSection extends StatefulWidget {
+  const _WeeklyMenuSection({required this.detail, required this.onReload});
+
+  final StoreDetail detail;
+  final Future<void> Function() onReload;
+
+  @override
+  State<_WeeklyMenuSection> createState() => _WeeklyMenuSectionState();
+}
+
+class _WeeklyMenuSectionState extends State<_WeeklyMenuSection> {
+  static const _cardWidth = 148.0;
+  static const _cardGap = 12.0;
+
+  final ScrollController _singleController = ScrollController();
+  final Map<int, ScrollController> _groupControllers = <int, ScrollController>{};
+
+  @override
+  void dispose() {
+    _singleController.dispose();
+    for (final c in _groupControllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _jumpToTodayIfPossible());
+  }
+
+  @override
+  void didUpdateWidget(covariant _WeeklyMenuSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.detail.weeklyMenuResponse != widget.detail.weeklyMenuResponse) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _jumpToTodayIfPossible());
+    }
+  }
+
+  void _jumpToTodayIfPossible() {
+    final weekly = widget.detail.weeklyMenuResponse;
+    if (weekly == null) return;
+    final days = _weekdayMenus(weekly);
+    if (days.isEmpty) return;
+
+    final today = kstTodayYmd();
+    final idx = days.indexWhere((d) => d.date == today);
+    if (idx < 0) return;
+
+    final offset = (_cardWidth + _cardGap) * idx;
+
+    void animate(ScrollController c) {
+      if (!c.hasClients) return;
+      c.animateTo(
+        offset.clamp(0, c.position.maxScrollExtent),
+        duration: const Duration(milliseconds: 280),
+        curve: Curves.easeOut,
+      );
+    }
+
+    // 단일 그룹(또는 그룹 통합 카드) 스크롤
+    animate(_singleController);
+
+    // 다중 그룹: 모든 그룹별 리스트도 오늘 카드로 이동
+    for (final c in _groupControllers.values) {
+      animate(c);
+    }
+  }
+
+  List<StoreWeeklyMenuDay> _weekdayMenus(WeeklyMenuResponse weekly) {
+    const weekdays = {'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY'};
+    final list = weekly.dailyMenus.where((d) => weekdays.contains(d.dayOfWeek)).toList();
+    list.sort((a, b) => a.date.compareTo(b.date));
+    return list;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final weekly = widget.detail.weeklyMenuResponse;
+    final today = kstTodayYmd();
+
+    final titleRow = Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        const Text(
+          '일주일 메뉴',
+          style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+        ),
+        IconButton(
+          onPressed: widget.onReload,
+          icon: const Icon(Icons.refresh, color: Color(0xFF9CA3AF)),
+          tooltip: '새로고침',
+        ),
+      ],
+    );
+
+    if (weekly == null) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          titleRow,
+          const SizedBox(height: 8),
+          const Text('메뉴 정보를 불러올 수 없습니다.', style: TextStyle(color: Color(0xFF9CA3AF))),
+        ],
+      );
+    }
+
+    final days = _weekdayMenus(weekly);
+    if (days.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          titleRow,
+          const SizedBox(height: 8),
+          const Text('표시할 메뉴가 없습니다.', style: TextStyle(color: Color(0xFF9CA3AF))),
+        ],
+      );
+    }
+
+    // 그룹 목록(첫 날 기준, sortOrder)
+    final first = days.first;
+    final groups = [...first.groups]..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    final singleGroup = groups.length <= 1;
+
+    ScrollController controllerForGroup(StoreDetailDayGroup? group) {
+      if (group == null) return _singleController;
+      return _groupControllers.putIfAbsent(group.groupId, () => ScrollController());
+    }
+
+    Widget buildCardsForGroup(StoreDetailDayGroup? group) {
+      return SizedBox(
+        height: 160,
+        child: ListView.builder(
+          controller: controllerForGroup(group),
+          scrollDirection: Axis.horizontal,
+          itemCount: days.length,
+          itemBuilder: (context, index) {
+            final d = days[index];
+            final dateLabel = _formatMmDd(d.date);
+            final dayLabel = _korDayLabel(d.dayOfWeek);
+            final items = group == null
+                ? d.groups.expand((g) => g.menus).toList(growable: false)
+                : (d.groups.firstWhere(
+                        (g) => g.groupId == group.groupId,
+                        orElse: () => StoreDetailDayGroup(
+                          groupId: group.groupId,
+                          name: group.name,
+                          sortOrder: group.sortOrder,
+                          stock: 0,
+                          capacity: 0,
+                          menus: const [],
+                        ),
+                      ).menus);
+            return WeeklyMenuCard(
+              dateLabel: dateLabel,
+              dayLabel: dayLabel,
+              items: items,
+            );
+          },
+        ),
+      );
+    }
+
+    int singleRemain() {
+      final todayDaily = days.where((d) => d.date == today).cast<StoreWeeklyMenuDay?>().firstWhere((_) => true, orElse: () => null);
+      if (todayDaily == null) return widget.detail.remain ?? 0;
+      if (todayDaily.groups.isNotEmpty) return todayDaily.groups.first.stock;
+      return widget.detail.remain ?? 0;
+    }
+
+    int groupRemain(int groupId) {
+      final todayDaily = days.where((d) => d.date == today).cast<StoreWeeklyMenuDay?>().firstWhere((_) => true, orElse: () => null);
+      if (todayDaily == null) return 0;
+      final g = todayDaily.groups.where((e) => e.groupId == groupId).cast<StoreDetailDayGroup?>().firstWhere((_) => true, orElse: () => null);
+      return g?.stock ?? 0;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        titleRow,
+        const SizedBox(height: 10),
+        if (singleGroup) ...[
+          buildCardsForGroup(null),
+          const SizedBox(height: 10),
+          Text(
+            '남은 수량 : ${singleRemain()}개',
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFFFF6E3F),
+            ),
+          ),
+        ] else ...[
+          for (final g in groups) ...[
+            Text(
+              g.name,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700, color: Color(0xFF111827)),
+            ),
+            const SizedBox(height: 8),
+            buildCardsForGroup(g),
+            const SizedBox(height: 10),
+            Text(
+              '남은 수량 : ${groupRemain(g.groupId)}개',
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: Color(0xFFFF6E3F),
+              ),
+            ),
+            const SizedBox(height: 18),
+          ],
+        ],
+      ],
+    );
+  }
+
+  String _formatMmDd(String ymd) {
+    // YYYY-MM-DD -> MM월 DD일
+    if (ymd.length < 10) return ymd;
+    final mm = ymd.substring(5, 7);
+    final dd = ymd.substring(8, 10);
+    return '$mm월 $dd일';
+  }
+
+  String _korDayLabel(String dayOfWeek) {
+    switch (dayOfWeek) {
+      case 'MONDAY':
+        return '월요일';
+      case 'TUESDAY':
+        return '화요일';
+      case 'WEDNESDAY':
+        return '수요일';
+      case 'THURSDAY':
+        return '목요일';
+      case 'FRIDAY':
+        return '금요일';
+      case 'SATURDAY':
+        return '토요일';
+      case 'SUNDAY':
+        return '일요일';
+      default:
+        return dayOfWeek;
+    }
   }
 }

--- a/lib/features/store/widgets/weekly_menu_card.dart
+++ b/lib/features/store/widgets/weekly_menu_card.dart
@@ -14,6 +14,7 @@ class WeeklyMenuCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final safeItems = items.where((e) => e.trim().isNotEmpty).toList(growable: false);
     return Container(
       width: 148,
       margin: const EdgeInsets.only(right: 12),
@@ -53,21 +54,30 @@ class WeeklyMenuCard extends StatelessWidget {
           const SizedBox(height: 8),
           Container(height: 1, color: const Color(0xFFE5E7EB)),
           const SizedBox(height: 10),
-          if (items.isEmpty)
-            const Text('메뉴 없음', style: TextStyle(color: Color(0xFF9CA3AF)))
-          else
-            ...items.map(
-              (menu) => Padding(
-                padding: const EdgeInsets.only(bottom: 6),
-                child: Text(
-                  menu,
-                  style: const TextStyle(
-                    fontSize: 13,
-                    color: Color(0xFF4B5563),
+          Expanded(
+            child: safeItems.isEmpty
+                ? const Align(
+                    alignment: Alignment.topLeft,
+                    child: Text('메뉴 없음', style: TextStyle(color: Color(0xFF9CA3AF))),
+                  )
+                : ScrollConfiguration(
+                    behavior: ScrollConfiguration.of(context).copyWith(scrollbars: false),
+                    child: ListView.separated(
+                      padding: EdgeInsets.zero,
+                      itemCount: safeItems.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 6),
+                      itemBuilder: (_, i) => Text(
+                        safeItems[i],
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 13,
+                          color: Color(0xFF4B5563),
+                        ),
+                      ),
+                    ),
                   ),
-                ),
-              ),
-            ),
+          ),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'features/admin/screens/admin_menu_screen.dart';
 import 'features/admin/screens/admin_menu_edit_screen.dart';
 import 'features/admin/screens/admin_frequent_menu_screen.dart';
 import 'features/admin/screens/admin_frequent_menu_edit_screen.dart';
+import 'features/admin/screens/admin_settings_screen.dart';
 import 'features/admin/viewmodels/admin_home_view_model.dart';
 import 'features/admin/viewmodels/admin_inventory_view_model.dart';
 import 'features/admin/viewmodels/admin_menu_view_model.dart';
@@ -168,6 +169,10 @@ class MyApp extends StatelessWidget {
                 );
               },
             ),
+          ),
+          AdminSettingsScreen.routeName: (_) => const RoleGuard(
+            targetRole: Role.admin,
+            child: AdminSettingsScreen(),
           ),
           MyPageScreen.routeName: (_) =>
               const RoleGuard(targetRole: Role.student, child: MyPageScreen()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -124,11 +124,21 @@ class MyApp extends StatelessWidget {
             child: Builder(
               builder: (context) {
                 final args = ModalRoute.of(context)?.settings.arguments;
-                final initialDate = args is String ? args : null;
+                String? initialDate;
+                int? groupId;
+                if (args is String) {
+                  initialDate = args;
+                } else if (args is Map) {
+                  final date = args['date'];
+                  final gid = args['groupId'];
+                  if (date is String) initialDate = date;
+                  if (gid is int) groupId = gid;
+                }
                 return ChangeNotifierProvider(
                   create: (_) => AdminMenuEditViewModel(
                     context.read<AdminRepository>(),
                     initialDate: initialDate,
+                    groupId: groupId,
                   ),
                   child: AdminMenuEditScreen(initialDate: initialDate),
                 );

--- a/lib/widgets/StoreCard.dart
+++ b/lib/widgets/StoreCard.dart
@@ -1,25 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:meal_app/util/colors.dart';
 
-// 1. 데이터 모델 정의 (React의 StoreListItem 대응)
-class Store {
-  final int id;
-  final String name;
-  final String? imageUrl;
-  final List<String> menus; // todayMenu.menus 대신 단순화
-  final int remain;
-
-  Store({
-    required this.id,
-    required this.name,
-    this.imageUrl,
-    required this.menus,
-    required this.remain,
-  });
-}
+import '../features/store/models/store_models.dart';
 
 class StoreCard extends StatelessWidget {
-  final Store store;
+  final StoreListItem store;
   final bool isSelected;
   final VoidCallback? onTap;
 
@@ -32,10 +17,8 @@ class StoreCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 메뉴 텍스트 로직 (join)
-    final String menusText = store.menus.isNotEmpty
-        ? store.menus.join(', ')
-        : '메뉴 정보 없음';
+    final groups = [...store.menuGroups]..sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
+    final isMultiGroup = groups.length >= 2;
 
     return GestureDetector(
       onTap: () {
@@ -62,34 +45,156 @@ class StoreCard extends StatelessWidget {
             ),
           ],
         ),
-        child: Row(
-          children: [
-            // 좌측 매장 이미지 -> 크기가 전부 달랐었는데, 50*50 고정 박스 안에 BoxFit.contain으로 넣어 맞춤  -> 해결
-            ClipRRect(
-              borderRadius: BorderRadius.circular(8), // rounded-lg
-              child: SizedBox(
-                width: 50,
-                height: 50,
-                child: Center(
-                  child: SizedBox(
-                    width: 50,
-                    height: 50,
-                    child: store.imageUrl != null && store.imageUrl!.isNotEmpty
-                        ? _buildStoreImage(store.imageUrl!)
-                        : _buildNoImage(),
-                  ),
+        child: !isMultiGroup
+            ? _SingleGroupLayout(store: store)
+            : _MultiGroupLayout(store: store, groups: groups),
+      ),
+    );
+  }
+
+}
+
+class _SingleGroupLayout extends StatelessWidget {
+  const _SingleGroupLayout({required this.store});
+
+  final StoreListItem store;
+
+  static const double _imageSize = 48;
+
+  @override
+  Widget build(BuildContext context) {
+    final menusText = store.singleGroupMenusText;
+    final stock = store.firstGroupStock;
+
+    return Row(
+      children: [
+        _StoreImageBox(imageUrl: store.imageUrl, size: _imageSize),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                store.name,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.black87,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                menusText,
+                style: TextStyle(fontSize: 14, color: Colors.grey[600]),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 16),
+        SizedBox(
+          width: 64,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                "$stock개",
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: stock == 0 ? Colors.red : AppColors.primary,
                 ),
               ),
-            ),
+              Text(
+                "남았어요!",
+                style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
 
-            const SizedBox(width: 16),
-            // 가게 정보
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // 매장명
-                  Text(
+class _MultiGroupLayout extends StatelessWidget {
+  const _MultiGroupLayout({required this.store, required this.groups});
+
+  final StoreListItem store;
+  final List<TodayMenuGroup> groups;
+
+  static const double _rowHeight = 56;
+  static const double _imageSize = 48;
+  static const double _dotSize = 6;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: _imageSize,
+          child: Column(
+            children: [
+              _StoreImageBox(imageUrl: store.imageUrl, size: _imageSize),
+              const SizedBox(height: 2),
+              SizedBox(
+                height: _rowHeight * groups.length,
+                child: Stack(
+                  alignment: Alignment.topCenter,
+                  children: [
+                    Positioned(
+                      top: 0,
+                      // 마지막 점의 중앙까지 이어지도록 bottom 을 rowHeight/2 로 둔다.
+                      bottom: _rowHeight / 2,
+                      child: SizedBox(
+                        width: 2,
+                        child: CustomPaint(
+                          painter: _VerticalDashedLinePainter(
+                            color: Color(0xFFD1D5DB),
+                            dashHeight: 6,
+                            dashGap: 4,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Column(
+                      children: [
+                        for (int i = 0; i < groups.length; i++)
+                          SizedBox(
+                            height: _rowHeight,
+                            child: Center(
+                              child: Container(
+                                width: _dotSize,
+                                height: _dotSize,
+                                decoration: const BoxDecoration(
+                                  color: Color(0xFF9CA3AF),
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: 50,
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
                     store.name,
                     style: const TextStyle(
                       fontSize: 16,
@@ -99,91 +204,164 @@ class StoreCard extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: 4),
-                  // 메뉴 목록
-                  Text(
-                    menusText,
-                    style: TextStyle(fontSize: 14, color: Colors.grey[600]),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
+                ),
               ),
-            ),
-
-            const SizedBox(width: 16),
-            // 남은 개수
-            SizedBox(
-              width: 64,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    "${store.remain}개",
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                      // 색상 로직: 0개면 빨강, 아니면 주황
-                      color: store.remain == 0 ? Colors.red : AppColors.primary,
+              for (final g in groups)
+                SizedBox(
+                  height: _rowHeight,
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      g.menus.isNotEmpty ? g.menus.map((e) => e.name).join(', ') : '메뉴 정보 없음',
+                      style: TextStyle(fontSize: 14, color: Colors.grey[600]),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                  Text(
-                    "남았어요!",
-                    style: TextStyle(fontSize: 12, color: Colors.grey[500]),
-                  ),
-                ],
-              ),
-            ),
-          ],
+                ),
+            ],
+          ),
         ),
-      ),
+        const SizedBox(width: 16),
+        SizedBox(
+          width: 64,
+          child: Column(
+            children: [
+              const SizedBox(height: 50),
+              for (final g in groups)
+                SizedBox(
+                  height: _rowHeight,
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Text(
+                        "${g.stock}개",
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: g.stock == 0 ? Colors.red : AppColors.primary,
+                        ),
+                      ),
+                      Text(
+                        "남았어요!",
+                        style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                      ),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
     );
   }
+}
 
-  // 이미지 없을 때 보여줄 위젯 (No Img)
-  Widget _buildNoImage() {
-    return Container(
-      color: Colors.grey[200],
-      alignment: Alignment.center,
-      child: Text(
-        "No Img",
-        style: TextStyle(fontSize: 10, color: Colors.grey[500]),
-      ),
-    );
-  }
+Widget _buildNoImage() {
+  return Container(
+    color: Colors.grey[200],
+    alignment: Alignment.center,
+    child: Text(
+      "No Img",
+      style: TextStyle(fontSize: 10, color: Colors.grey[500]),
+    ),
+  );
+}
 
-  Widget _buildStoreImage(String urlOrAsset) {
-    final value = urlOrAsset.trim();
-    final isNetwork =
-        value.startsWith('http://') || value.startsWith('https://');
-    if (isNetwork) {
-      return Image.network(
-        value,
-        fit: BoxFit.contain,
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) return child;
-          return Center(
-            child: SizedBox(
-              width: 16,
-              height: 16,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                value: loadingProgress.expectedTotalBytes != null
-                    ? loadingProgress.cumulativeBytesLoaded /
-                          (loadingProgress.expectedTotalBytes ?? 1)
-                    : null,
-              ),
-            ),
-          );
-        },
-        errorBuilder: (context, error, stackTrace) => _buildNoImage(),
-      );
-    }
-
-    return Image.asset(
+Widget _buildStoreImage(String urlOrAsset) {
+  final value = urlOrAsset.trim();
+  final isNetwork = value.startsWith('http://') || value.startsWith('https://');
+  if (isNetwork) {
+    return Image.network(
       value,
       fit: BoxFit.contain,
+      loadingBuilder: (context, child, loadingProgress) {
+        if (loadingProgress == null) return child;
+        return Center(
+          child: SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              value: loadingProgress.expectedTotalBytes != null
+                  ? loadingProgress.cumulativeBytesLoaded / (loadingProgress.expectedTotalBytes ?? 1)
+                  : null,
+            ),
+          ),
+        );
+      },
       errorBuilder: (context, error, stackTrace) => _buildNoImage(),
     );
+  }
+
+  return Image.asset(
+    value,
+    fit: BoxFit.contain,
+    errorBuilder: (context, error, stackTrace) => _buildNoImage(),
+  );
+}
+
+class _StoreImageBox extends StatelessWidget {
+  const _StoreImageBox({required this.imageUrl, required this.size});
+
+  final String? imageUrl;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final url = (imageUrl ?? '').trim();
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12), // rounded-xl
+      child: Container(
+        width: size,
+        height: size,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              Colors.white,
+              Color(0x33FFA588), // rgba(255,165,136,0.2)
+            ],
+          ),
+        ),
+        child: url.isNotEmpty ? _buildStoreImage(url) : _buildNoImage(),
+      ),
+    );
+  }
+}
+
+class _VerticalDashedLinePainter extends CustomPainter {
+  _VerticalDashedLinePainter({
+    required this.color,
+    required this.dashHeight,
+    required this.dashGap,
+  });
+
+  final Color color;
+  final double dashHeight;
+  final double dashGap;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = size.width
+      ..style = PaintingStyle.stroke;
+
+    double y = 0;
+    final x = size.width / 2;
+    while (y < size.height) {
+      final y2 = (y + dashHeight).clamp(0, size.height).toDouble();
+      canvas.drawLine(Offset(x, y), Offset(x, y2), paint);
+      y += dashHeight + dashGap;
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _VerticalDashedLinePainter oldDelegate) {
+    return oldDelegate.color != color ||
+        oldDelegate.dashHeight != dashHeight ||
+        oldDelegate.dashGap != dashGap;
   }
 }

--- a/lib/widgets/StoreSection.dart
+++ b/lib/widgets/StoreSection.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../features/store/models/store_models.dart';
 import '../features/store/screens/store_detail_screen.dart';
 import '../features/store/viewmodels/store_list_view_model.dart';
 import 'StoreCard.dart';
@@ -23,20 +22,10 @@ class _StoreSectionState extends State<StoreSection> {
     });
   }
 
-  Store _toUi(StoreListItem item) {
-    return Store(
-      id: item.id,
-      name: item.name,
-      menus: item.menus,
-      remain: item.remain,
-      imageUrl: item.imageUrl,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<StoreListViewModel>();
-    final stores = vm.items.map(_toUi).toList();
+    final stores = vm.items;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),


### PR DESCRIPTION
## 배경
- 메뉴관리 도메인을 **메뉴그룹 기반**으로 리팩토링하고, Flutter UI를 피그마(Next.js 기준)와 동기화합니다.
- 관리자 탭 내부 라우팅은 **push로 진입 → pop으로 복귀**되도록 정리합니다.

### 관련 이슈
close #17 

## 주요 변경사항
### 1) 메뉴관리(관리자) 그룹 기반 리팩토링
- **주간/일간 메뉴 조회 API를 groups 엔드포인트로 전환** 및 DTO/모델 정비
- `AdminMenuScreen`
  - 그룹 칩 UI/주간 카드 레이아웃 개선(피그마 구조 반영)
  - 특정 날짜 탭 → `AdminMenuEditScreen`로 `date + groupId` 전달
- `AdminMenuEditScreen`
  - 주말 비활성(토/일 클릭 불가 + 회색 처리)
  - 입력바 UI 정리(햄버거 아이콘, 클리어 버튼, 버튼/필드 높이 맞춤)
  - 메뉴 리스트 UI 정리(인덱스/구분선/삭제 원형 X)
  - 자주쓰는 메뉴 드롭다운 연동

### 2) 자주 쓰는 메뉴(즐겨찾기) 리팩토링
- 목록 화면: 당겨서 새로고침 추가, FAB 위치 정리
- 편집 화면: 입력바/삭제 UI를 메뉴수정 화면과 동일한 스타일로 통일
- `FavoriteGroup` 모델 파싱/alias(getter)로 참조 일관성 개선

### 3) 재고관리(관리자) 그룹 기반 반영
- 그룹별 재고 증감/차감(1/5/10) 흐름 정리 및 관련 API/모델 반영

### 4) 네비게이션(back) 정책 통일
- 관리자 하위 라우트(메뉴관리/자주쓰는 메뉴/편집)에서 `pushNamedAndRemoveUntil` 제거
- **뒤로가기 = pop** (dirty confirm은 pop 허용/차단만 처리)
- 로그인 화면 뒤로가기:
  - 스택이 있으면 pop
  - `initialRoute` 등으로 pop 불가하면 `/`로 fallback

### 5) 관리자 설정 화면 추가
- 관리자 대시보드 헤더: 좌측 텍스트 제거 + 우측 설정 아이콘
- 설정 화면: 회원정보 수정 / 비밀번호 변경 / 로그아웃 / 회원탈퇴 진입 제공
- 관리자 대시보드 상단 흰색 바가 프로필 카드 아래까지 내려오도록 배경 구조 정리(마이페이지와 일관)

## 변경 파일(요약)
- Admin: `admin_menu_screen`, `admin_menu_edit_screen`, `admin_frequent_menu_*`, `admin_inventory_screen`, `admin_home_screen`, `admin_settings_screen`
- API/Repo/Model: `admin_api`, `admin_repository`, `menu_models`, `dio_client(patch)`
- Routing: `main.dart`
- Auth: `login_screen`

## 테스트
- `flutter test`

## 비고 / 후속 작업
- 피그마 픽셀 단위 미세 조정이 필요한 경우(간격/색상/아이콘 크기 등) 추가 반영 예정