### PR TITLE
[QA] 기능적 QA 수정 

### DIFF
--- a/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
+++ b/lib/features/admin/screens/admin_frequent_menu_edit_screen.dart
@@ -13,13 +13,19 @@ class AdminFrequentMenuEditScreen extends StatefulWidget {
   final int groupId; // 일일 메뉴 그룹 ID (필수)
   final int? presetId; // null이면 새로 만들기, 있으면 수정
 
-  const AdminFrequentMenuEditScreen({super.key, required this.groupId, this.presetId});
+  const AdminFrequentMenuEditScreen({
+    super.key,
+    required this.groupId,
+    this.presetId,
+  });
 
   @override
-  State<AdminFrequentMenuEditScreen> createState() => _AdminFrequentMenuEditScreenState();
+  State<AdminFrequentMenuEditScreen> createState() =>
+      _AdminFrequentMenuEditScreenState();
 }
 
-class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScreen> {
+class _AdminFrequentMenuEditScreenState
+    extends State<AdminFrequentMenuEditScreen> {
   bool _loaded = false;
   Timer? _toastTimer;
   final TextEditingController _controller = TextEditingController();
@@ -36,7 +42,9 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
     super.didChangeDependencies();
     if (_loaded) return;
     _loaded = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) => context.read<AdminFrequentMenuEditViewModel>().init());
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => context.read<AdminFrequentMenuEditViewModel>().init(),
+    );
   }
 
   Future<bool> _confirmDiscardIfDirty(AdminFrequentMenuEditViewModel vm) async {
@@ -98,22 +106,56 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
             Padding(
               padding: const EdgeInsets.only(right: 12),
               child: ElevatedButton(
-                onPressed: vm.saving
+                onPressed:
+                    (vm.saving || !vm.dirty) // 저장 중이거나 변경사항이 없으면 비활성화
                     ? null
                     : () async {
-                        await context.read<AdminFrequentMenuEditViewModel>().save();
+                        await context
+                            .read<AdminFrequentMenuEditViewModel>()
+                            .save();
+                        if (!context.mounted) return;
+                        // 저장 성공 시 토스트 후 이전 화면으로 이동
+                        final savedVm = context
+                            .read<AdminFrequentMenuEditViewModel>();
+                        if (savedVm.errorMessage == null) {
+                          await Future.delayed(
+                            const Duration(milliseconds: 400),
+                          ); // 0.4초 대기 (저장되었습니다 토스트가 보이도록)
+                          if (!context.mounted) return;
+                          Navigator.of(context).pop(true); //저장 완료되면 이전 화면으로 pop
+                        }
                       },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: const Color(0xFFF97316),
                   foregroundColor: Colors.white,
                   elevation: 0,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
                   minimumSize: Size.zero,
                 ),
                 child: vm.saving
-                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
-                    : const Text('저장', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : Text(
+                        '저장',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w600,
+                          // 변경사항 있으면 흰색, 없으면 반투명으로 비활성화 상태 구분
+                          color: vm.dirty ? Colors.white : Colors.white60,
+                        ),
+                      ),
               ),
             ),
           ],
@@ -125,7 +167,9 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
               child: Column(
                 children: [
                   if (vm.loading)
-                    const Expanded(child: Center(child: CircularProgressIndicator()))
+                    const Expanded(
+                      child: Center(child: CircularProgressIndicator()),
+                    )
                   else
                     Expanded(
                       child: ListView(
@@ -133,13 +177,19 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
                         children: [
                           _InputBar(
                             controller: _controller,
-                            onChanged: (v) => context.read<AdminFrequentMenuEditViewModel>().setInput(v),
-                            onAdd: () => context.read<AdminFrequentMenuEditViewModel>().addMenu(),
+                            onChanged: (v) => context
+                                .read<AdminFrequentMenuEditViewModel>()
+                                .setInput(v),
+                            onAdd: () => context
+                                .read<AdminFrequentMenuEditViewModel>()
+                                .addMenu(),
                           ),
                           const SizedBox(height: 16),
                           _MenuList(
                             menus: vm.menus,
-                            onRemove: (i) => context.read<AdminFrequentMenuEditViewModel>().removeMenu(i),
+                            onRemove: (i) => context
+                                .read<AdminFrequentMenuEditViewModel>()
+                                .removeMenu(i),
                           ),
                         ],
                       ),
@@ -153,9 +203,18 @@ class _AdminFrequentMenuEditScreenState extends State<AdminFrequentMenuEditScree
                 child: Padding(
                   padding: const EdgeInsets.only(bottom: 24),
                   child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                    decoration: BoxDecoration(color: const Color(0xFF111827), borderRadius: BorderRadius.circular(999)),
-                    child: const Text('저장되었습니다', style: TextStyle(color: Colors.white, fontSize: 12)),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 10,
+                    ),
+                    decoration: BoxDecoration(
+                      color: const Color(0xFF111827),
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: const Text(
+                      '저장되었습니다',
+                      style: TextStyle(color: Colors.white, fontSize: 12),
+                    ),
                   ),
                 ),
               ),
@@ -171,7 +230,11 @@ class _InputBar extends StatelessWidget {
   final ValueChanged<String> onChanged;
   final VoidCallback onAdd;
 
-  const _InputBar({required this.controller, required this.onChanged, required this.onAdd});
+  const _InputBar({
+    required this.controller,
+    required this.onChanged,
+    required this.onAdd,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -187,19 +250,34 @@ class _InputBar extends StatelessWidget {
                   hintText: '메뉴 입력',
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
-                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1), // stone-300
+                    borderSide: const BorderSide(
+                      color: Color(0xFFD6D3D1),
+                      width: 1,
+                    ), // stone-300
                   ),
                   enabledBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
-                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1),
+                    borderSide: const BorderSide(
+                      color: Color(0xFFD6D3D1),
+                      width: 1,
+                    ),
                   ),
                   focusedBorder: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
-                    borderSide: const BorderSide(color: Color(0xFFD6D3D1), width: 1),
+                    borderSide: const BorderSide(
+                      color: Color(0xFFD6D3D1),
+                      width: 1,
+                    ),
                   ),
-                  contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 10,
+                  ),
                   isDense: true,
-                  suffixIconConstraints: const BoxConstraints.tightFor(width: 40, height: 40),
+                  suffixIconConstraints: const BoxConstraints.tightFor(
+                    width: 40,
+                    height: 40,
+                  ),
                   suffixIcon: controller.text.isEmpty
                       ? null
                       : Center(
@@ -214,7 +292,11 @@ class _InputBar extends StatelessWidget {
                                 shape: BoxShape.circle,
                               ),
                               child: const Center(
-                                child: Icon(Icons.close, size: 10, color: Colors.white),
+                                child: Icon(
+                                  Icons.close,
+                                  size: 10,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
                           ),
@@ -235,11 +317,16 @@ class _InputBar extends StatelessWidget {
               backgroundColor: const Color(0xFFE5E7EB),
               foregroundColor: const Color(0xFF111827),
               elevation: 0,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               minimumSize: const Size(60, 40),
             ),
-            child: const Text('입력', style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
+            child: const Text(
+              '입력',
+              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+            ),
           ),
         ],
       ),
@@ -257,7 +344,14 @@ class _MenuList extends StatelessWidget {
   Widget build(BuildContext context) {
     if (menus.isEmpty) {
       return const Center(
-        child: Text('현재 작성된 메뉴가 없습니다', style: TextStyle(color: Color(0xFF9CA3AF), fontSize: 14, fontWeight: FontWeight.w600)),
+        child: Text(
+          '현재 작성된 메뉴가 없습니다',
+          style: TextStyle(
+            color: Color(0xFF9CA3AF),
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
       );
     }
 
@@ -274,14 +368,20 @@ class _MenuList extends StatelessWidget {
                   child: Text(
                     '${i + 1}',
                     textAlign: TextAlign.right,
-                    style: const TextStyle(fontSize: 14, color: Color(0xFF6B7280)),
+                    style: const TextStyle(
+                      fontSize: 14,
+                      color: Color(0xFF6B7280),
+                    ),
                   ),
                 ),
                 const SizedBox(width: 12),
                 Container(width: 1, height: 20, color: const Color(0xFFD1D5DB)),
                 const SizedBox(width: 12),
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
                   decoration: BoxDecoration(
                     color: const Color(0xFFFFF7ED), // orange-50
                     borderRadius: BorderRadius.circular(999),
@@ -291,24 +391,31 @@ class _MenuList extends StatelessWidget {
                     children: [
                       Text(
                         menus[i],
-                        style: const TextStyle(fontSize: 14, color: Color(0xFF1F2937)),
+                        style: const TextStyle(
+                          fontSize: 14,
+                          color: Color(0xFF1F2937),
+                        ),
                       ),
                       const SizedBox(width: 8),
-                        InkWell(
-                          onTap: () => onRemove(i),
-                          borderRadius: BorderRadius.circular(999),
-                          child: Container(
-                            width: 15,
-                            height: 15,
-                            decoration: const BoxDecoration(
-                              color: Color(0xFFA1A1A1), // neutral-400
-                              shape: BoxShape.circle,
-                            ),
-                            child: const Center(
-                              child: Icon(Icons.close, size: 10, color: Colors.white),
+                      InkWell(
+                        onTap: () => onRemove(i),
+                        borderRadius: BorderRadius.circular(999),
+                        child: Container(
+                          width: 15,
+                          height: 15,
+                          decoration: const BoxDecoration(
+                            color: Color(0xFFA1A1A1), // neutral-400
+                            shape: BoxShape.circle,
+                          ),
+                          child: const Center(
+                            child: Icon(
+                              Icons.close,
+                              size: 10,
+                              color: Colors.white,
                             ),
                           ),
                         ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/foundation.dart';
+import 'package:collection/collection.dart';
 
 import '../../../common/dio/api_error_mapper.dart';
 import '../../../common/dio/api_exception.dart';
 import '../repositories/admin_repository.dart';
 
 class AdminFrequentMenuEditViewModel extends ChangeNotifier {
-  AdminFrequentMenuEditViewModel(this._repo, {required this.groupId, this.presetId});
+  AdminFrequentMenuEditViewModel(
+    this._repo, {
+    required this.groupId,
+    this.presetId,
+  });
 
   final AdminRepository _repo;
   final int groupId; // 일일 메뉴 그룹 ID
@@ -15,6 +20,7 @@ class AdminFrequentMenuEditViewModel extends ChangeNotifier {
   bool saving = false;
   String? errorMessage;
   List<String> menus = [];
+  List<String> _initialMenus = []; // 서버에서 불러온 초기 메뉴 (dirty 비교용)
   String input = '';
   bool dirty = false;
   bool showConfirm = false;
@@ -27,8 +33,13 @@ class AdminFrequentMenuEditViewModel extends ChangeNotifier {
     errorMessage = null;
     notifyListeners();
     try {
-      final detail = await _repo.getMenuPresetDetail(groupId: groupId, presetId: presetId!);
+      final detail = await _repo.getMenuPresetDetail(
+        groupId: groupId,
+        presetId: presetId!,
+      );
       menus = List<String>.from(detail.menus);
+      _initialMenus = List<String>.from(menus); //서버에서 받은 메뉴를 초기 상태로 저장
+      dirty = false;
     } catch (e) {
       if (e is ApiException) {
         errorMessage = mapErrorToMessage(e, responseData: e.details);
@@ -46,18 +57,30 @@ class AdminFrequentMenuEditViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  // menus와 _initialMenus를 비교해서 dirty 상태 업데이트
+  void _updateDirty() {
+    dirty = !const ListEquality<String>().equals(menus, _initialMenus);
+  }
+
   void addMenu() {
+    // 기존에는 dirty = true로 바로 바꿨지만, _updateDirty()로 변경해서 menus와 _initialMenus를 비교하도록 수정.
     final text = input.trim();
     if (text.isEmpty) return;
     menus = [...menus, text];
     input = '';
-    dirty = true;
+    _updateDirty();
     notifyListeners();
   }
 
   void removeMenu(int index) {
-    menus = menus.asMap().entries.where((entry) => entry.key != index).map((entry) => entry.value).toList();
-    dirty = true;
+    // 기존에는 dirty = true로 바로 바꿨지만, _updateDirty()로 변경해서 menus와 _initialMenus를 비교하도록 수정.
+    menus = menus
+        .asMap()
+        .entries
+        .where((entry) => entry.key != index)
+        .map((entry) => entry.value)
+        .toList();
+    _updateDirty();
     notifyListeners();
   }
 
@@ -70,6 +93,8 @@ class AdminFrequentMenuEditViewModel extends ChangeNotifier {
         await _repo.deleteMenuPreset(groupId: groupId, presetId: presetId!);
       }
       await _repo.createMenuPreset(groupId: groupId, menus: menus);
+      // 저장 후 현재 메뉴를 새로운 초기 상태로 갱신하고 dirty 상태 업데이트
+      _initialMenus = List<String>.from(menus);
       dirty = false;
       showSavedToast = true;
       notifyListeners();

--- a/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_frequent_menu_edit_view_model.dart
@@ -89,10 +89,18 @@ class AdminFrequentMenuEditViewModel extends ChangeNotifier {
     errorMessage = null;
     notifyListeners();
     try {
-      if (presetId != null) {
+      if (menus.isEmpty && presetId != null) {
+        // 기존 프리셋에서 메뉴를 전부 삭제한 경우 -> 빈 배열 post (X) 프리셋 자체 삭제 (O)
         await _repo.deleteMenuPreset(groupId: groupId, presetId: presetId!);
+      } else if (menus.isNotEmpty) {
+        // 메뉴 1개 이상 있는 경우
+        if (presetId != null) {
+          // 수정 모드 -> 기존 프리셋 delete 후 새로 만들기
+          await _repo.deleteMenuPreset(groupId: groupId, presetId: presetId!);
+        }
+        //새로 만들기 모드에서는 post
+        await _repo.createMenuPreset(groupId: groupId, menus: menus);
       }
-      await _repo.createMenuPreset(groupId: groupId, menus: menus);
       // 저장 후 현재 메뉴를 새로운 초기 상태로 갱신하고 dirty 상태 업데이트
       _initialMenus = List<String>.from(menus);
       dirty = false;

--- a/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
+++ b/lib/features/admin/viewmodels/admin_menu_edit_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:collection/collection.dart';
 
 import '../../../common/dio/api_error_mapper.dart';
 import '../../../common/dio/api_exception.dart';
@@ -12,9 +13,12 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     this._repo, {
     String? initialDate,
     required this.groupId,
-  })  :
-        selectedId = initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd(),
-        mondayId = mondayOfYmd(initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd());
+  }) : selectedId = initialDate?.isNotEmpty == true
+           ? initialDate!
+           : kstTodayYmd(),
+       mondayId = mondayOfYmd(
+         initialDate?.isNotEmpty == true ? initialDate! : kstTodayYmd(),
+       );
 
   final AdminRepository _repo;
 
@@ -30,6 +34,7 @@ class AdminMenuEditViewModel extends ChangeNotifier {
   String? errorMessage;
 
   List<String> menus = [];
+  List<String> _initialMenus = []; // 서버에서 불러온 초기 메뉴 (dirty 비교용)
   String groupName = '';
 
   bool showSavedToast = false;
@@ -51,8 +56,12 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     try {
       final res = await _repo.getDailyMenu(date: selectedId);
       final groups = res?.groups ?? const <DailyMenuGroupItem>[];
-      final group = groups.where((g) => g.id == groupId).cast<DailyMenuGroupItem?>().firstWhere((_) => true, orElse: () => null);
+      final group = groups
+          .where((g) => g.id == groupId)
+          .cast<DailyMenuGroupItem?>()
+          .firstWhere((_) => true, orElse: () => null);
       menus = group?.menus ?? <String>[];
+      _initialMenus = List<String>.from(menus);
       groupName = group?.name ?? '';
       dirty = false;
     } catch (e) {
@@ -72,12 +81,16 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  void _updateDirty() {
+    dirty = !const ListEquality<String>().equals(menus, _initialMenus);
+  }
+
   void addMenu([String? menuText]) {
     final text = (menuText ?? input).trim();
     if (text.isEmpty) return;
     menus = [...menus, text];
     if (menuText == null) input = '';
-    dirty = true;
+    _updateDirty();
     notifyListeners();
   }
 
@@ -86,7 +99,7 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     final next = List<String>.from(menus);
     next.removeAt(idx);
     menus = next;
-    dirty = true;
+    _updateDirty();
     notifyListeners();
   }
 
@@ -97,7 +110,12 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     errorMessage = null;
     notifyListeners();
     try {
-      await _repo.upsertMenuGroupMenus(groupId: groupId!, date: selectedId, menus: menus);
+      await _repo.upsertMenuGroupMenus(
+        groupId: groupId!,
+        date: selectedId,
+        menus: menus,
+      );
+      _initialMenus = List<String>.from(menus);
       dirty = false;
       showSavedToast = true;
     } catch (e) {
@@ -158,9 +176,13 @@ class AdminMenuEditViewModel extends ChangeNotifier {
   Future<void> selectFrequentMenu(FavoriteGroup group) async {
     if (groupId == null) return;
     try {
-      final detail = await _repo.getMenuPresetDetail(groupId: groupId!, presetId: group.id);
+      final detail = await _repo.getMenuPresetDetail(
+        groupId: groupId!,
+        presetId: group.id,
+      );
       menus = [...menus, ...detail.menus];
-      dirty = true;
+      //프리셋 메뉴를 추가한 후 dirty 상태 업데이트
+      _updateDirty();
       showFrequentMenu = false;
       notifyListeners();
     } catch (_) {
@@ -181,4 +203,3 @@ class AdminMenuEditViewModel extends ChangeNotifier {
     await selectDate(nextMonday);
   }
 }
-

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -16,7 +16,9 @@ class LoginScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final vm = context.watch<LoginViewModel>();
     final isStudent = vm.role == Role.student;
-    final primary = isStudent ? const Color(0xFFF97316) : const Color(0xFF60A5FA);
+    final primary = isStudent
+        ? const Color(0xFFF97316)
+        : const Color(0xFF60A5FA);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -256,7 +258,9 @@ class _RoleTabs extends StatelessWidget {
       builder: (context, constraints) {
         final tabWidth = constraints.maxWidth / 2;
         final isStudent = role == Role.student;
-        final underlineColor = isStudent ? const Color(0xFFF97316) : const Color(0xFF60A5FA);
+        final underlineColor = isStudent
+            ? const Color(0xFFF97316)
+            : const Color(0xFF60A5FA);
 
         return Stack(
           alignment: Alignment.bottomCenter,
@@ -267,14 +271,18 @@ class _RoleTabs extends StatelessWidget {
                   child: _RoleTabButton(
                     label: '일반',
                     active: isStudent,
-                    onTap: onChanged == null ? null : () => onChanged!(Role.student),
+                    onTap: onChanged == null
+                        ? null
+                        : () => onChanged!(Role.student),
                   ),
                 ),
                 Expanded(
                   child: _RoleTabButton(
                     label: '관리자',
                     active: !isStudent,
-                    onTap: onChanged == null ? null : () => onChanged!(Role.admin),
+                    onTap: onChanged == null
+                        ? null
+                        : () => onChanged!(Role.admin),
                   ),
                 ),
               ],
@@ -283,7 +291,12 @@ class _RoleTabs extends StatelessWidget {
               left: 0,
               right: 0,
               bottom: 0,
-              child: SizedBox(height: 1, child: DecoratedBox(decoration: BoxDecoration(color: Color(0xFFE5E7EB)))),
+              child: SizedBox(
+                height: 1,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(color: Color(0xFFE5E7EB)),
+                ),
+              ),
             ),
             Positioned(
               left: 0,
@@ -292,7 +305,9 @@ class _RoleTabs extends StatelessWidget {
               child: AnimatedAlign(
                 duration: const Duration(milliseconds: 250),
                 curve: Curves.easeOutCubic,
-                alignment: isStudent ? Alignment.bottomLeft : Alignment.bottomRight,
+                alignment: isStudent
+                    ? Alignment.bottomLeft
+                    : Alignment.bottomRight,
                 child: AnimatedContainer(
                   duration: const Duration(milliseconds: 250),
                   curve: Curves.easeInOut,
@@ -356,17 +371,24 @@ class _HeroCopy extends StatelessWidget {
         duration: const Duration(milliseconds: 250),
         switchInCurve: Curves.easeIn,
         switchOutCurve: Curves.easeOut,
-        transitionBuilder: (child, animation) => FadeTransition(opacity: animation, child: child),
+        transitionBuilder: (child, animation) =>
+            FadeTransition(opacity: animation, child: child),
         child: Align(
           key: ValueKey<Role>(role),
           alignment: isAdmin ? Alignment.topRight : Alignment.topLeft,
           child: Column(
-            crossAxisAlignment: isAdmin ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+            crossAxisAlignment: isAdmin
+                ? CrossAxisAlignment.end
+                : CrossAxisAlignment.start,
             children: [
               Text(
                 isAdmin ? '당신의 준비가\n늘 편리하도록,' : '당신의 걸음이\n헛되지 않도록,',
                 textAlign: isAdmin ? TextAlign.right : TextAlign.left,
-                style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w700, height: 1.25),
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.w700,
+                  height: 1.25,
+                ),
               ),
               const SizedBox(height: 10),
               Image.asset(
@@ -408,7 +430,10 @@ class _LabeledTextField extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(label, style: const TextStyle(fontSize: 14, color: Color(0xFF4B5563))),
+        Text(
+          label,
+          style: const TextStyle(fontSize: 14, color: Color(0xFF4B5563)),
+        ),
         const SizedBox(height: 8),
         TextField(
           controller: controller,
@@ -443,7 +468,10 @@ class _PasswordField extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text('비밀번호', style: TextStyle(fontSize: 14, color: Color(0xFF4B5563))),
+        const Text(
+          '비밀번호',
+          style: TextStyle(fontSize: 14, color: Color(0xFF4B5563)),
+        ),
         const SizedBox(height: 8),
         TextField(
           controller: controller,
@@ -454,7 +482,10 @@ class _PasswordField extends StatelessWidget {
         ),
         if (errorText != null) ...[
           const SizedBox(height: 6),
-          Text(errorText!, style: const TextStyle(fontSize: 12, color: Color(0xFFEF4444))),
+          Text(
+            errorText!,
+            style: const TextStyle(fontSize: 12, color: Color(0xFFEF4444)),
+          ),
         ],
       ],
     );
@@ -479,23 +510,39 @@ class _BottomLinks extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: [
         TextButton(
-          onPressed: enabled ? () => Navigator.of(context).pushNamed('/find-account', arguments: 'id') : null,
+          onPressed: enabled
+              ? () => Navigator.of(
+                  context,
+                ).pushNamed('/find-account', arguments: 'id')
+              : null,
           style: style,
           child: const Text('아이디 찾기'),
         ),
-        const Text('|', style: TextStyle(fontSize: 12, color: Color(0xFFD1D5DB))),
+        const Text(
+          '|',
+          style: TextStyle(fontSize: 12, color: Color(0xFFD1D5DB)),
+        ),
         TextButton(
-          onPressed: enabled ? () => Navigator.of(context).pushNamed('/find-account', arguments: 'pw') : null,
+          onPressed: enabled
+              ? () => Navigator.of(
+                  context,
+                ).pushNamed('/find-account', arguments: 'pw')
+              : null,
           style: style,
           child: const Text('비밀번호 찾기'),
         ),
-        const Text('|', style: TextStyle(fontSize: 12, color: Color(0xFFD1D5DB))),
+        const Text(
+          '|',
+          style: TextStyle(fontSize: 12, color: Color(0xFFD1D5DB)),
+        ),
         TextButton(
           onPressed: enabled
               ? () {
                   Navigator.of(context).pushNamed('/signup').then((_) {
                     if (context.mounted) {
-                      context.read<SignupViewModel>().clearFromCredentialsFlag();
+                      context
+                          .read<SignupViewModel>()
+                          .clearFromCredentialsFlag();
                     }
                   });
                 }

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -22,12 +22,8 @@ class LoginScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: const AppBarCommon(
-        title: '',
-      ),
-      body: SafeArea(
-        child: _LoginBody(primary: primary),
-      ),
+      appBar: const AppBarCommon(title: ''),
+      body: SafeArea(child: _LoginBody(primary: primary)),
     );
   }
 }
@@ -67,8 +63,10 @@ class _LoginBodyState extends State<_LoginBody> {
         final role = await vm.submit();
         if (!mounted) return;
         if (role != null) {
-          Navigator.of(context).pushReplacementNamed(
+          // pushNamedAndRemoveUntil로 로그인 화면 스택에서 제거 후 이동
+          Navigator.of(context).pushNamedAndRemoveUntil(
             role == Role.admin ? '/admin' : '/',
+            (route) => false,
           );
         }
       }
@@ -90,10 +88,7 @@ class _LoginBodyState extends State<_LoginBody> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          _RoleTabs(
-            role: vm.role,
-            onChanged: vm.loading ? null : vm.setRole,
-          ),
+          _RoleTabs(role: vm.role, onChanged: vm.loading ? null : vm.setRole),
           const SizedBox(height: 18),
           _HeroCopy(role: vm.role),
           const SizedBox(height: 18),
@@ -135,8 +130,10 @@ class _LoginBodyState extends State<_LoginBody> {
                       ? () async {
                           final role = await vm.submit();
                           if (!context.mounted || role == null) return;
-                          Navigator.of(context).pushReplacementNamed(
+                          // 기존 스택을 모두 제거하고, role에 따라 홈(/) 또는 관리자(/admin) 화면으로 이동
+                          Navigator.of(context).pushNamedAndRemoveUntil(
                             role == Role.admin ? '/admin' : '/',
+                            (route) => false,
                           );
                         }
                       : null,
@@ -220,7 +217,9 @@ class _OptionChip extends StatelessWidget {
               height: 22,
               child: Checkbox(
                 value: value,
-                onChanged: onChanged == null ? null : (v) => onChanged!(v ?? false),
+                onChanged: onChanged == null
+                    ? null
+                    : (v) => onChanged!(v ?? false),
                 activeColor: primary,
                 fillColor: WidgetStateProperty.resolveWith((states) {
                   if (states.contains(WidgetState.selected)) return primary;

--- a/lib/features/map/widgets/_favorite_button.dart
+++ b/lib/features/map/widgets/_favorite_button.dart
@@ -11,7 +11,7 @@ class FavoriteButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final vm = Provider.of<StoreListViewModel>(context, listen: false);
-    final isFavorite = store.isFavorite ?? false;
+    final isFavorite = store.isFavorite;
     return IconButton(
       onPressed: () => vm.toggleFavorite(store),
       icon: SvgPicture.asset(

--- a/lib/features/signup/screens/signup_credentials_screen.dart
+++ b/lib/features/signup/screens/signup_credentials_screen.dart
@@ -14,7 +14,8 @@ class SignupCredentialsScreen extends StatefulWidget {
   const SignupCredentialsScreen({super.key});
 
   @override
-  State<SignupCredentialsScreen> createState() => _SignupCredentialsScreenState();
+  State<SignupCredentialsScreen> createState() =>
+      _SignupCredentialsScreenState();
 }
 
 class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
@@ -47,10 +48,7 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
               children: [
                 const _SignupHeader(),
                 const SizedBox(height: 28),
-                _InputName(
-                  value: vm.name,
-                  onChanged: vm.setName,
-                ),
+                _InputName(value: vm.name, onChanged: vm.setName),
                 const SizedBox(height: 18),
                 _InputPassword(
                   pw: vm.pw,
@@ -84,7 +82,13 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
                 ),
                 if (vm.submitError != null) ...[
                   const SizedBox(height: 12),
-                  Text(vm.submitError!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+                  Text(
+                    vm.submitError!,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: Color(0xFFDC2626),
+                    ),
+                  ),
                 ],
                 const SizedBox(height: 18),
                 AppButton(
@@ -96,7 +100,9 @@ class _SignupCredentialsScreenState extends State<SignupCredentialsScreen> {
                           final ok = await vm.submit();
                           if (!context.mounted) return;
                           if (ok) {
-                            Navigator.of(context).pushReplacementNamed('/login');
+                            Navigator.of(
+                              context,
+                            ).pushNamedAndRemoveUntil('/login', (r) => false);
                           }
                         }
                       : null,
@@ -122,14 +128,24 @@ class _SignupHeader extends StatelessWidget {
       children: [
         const Text(
           '천밥에 오신 것을\n환영합니다!',
-          style: TextStyle(fontSize: 24, fontWeight: FontWeight.w700, height: 1.25),
+          style: TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.w700,
+            height: 1.25,
+          ),
         ),
         const SizedBox(height: 8),
         RichText(
           text: TextSpan(
             style: TextStyle(fontSize: 12, color: Color(0xFF6B7280)),
             children: [
-              TextSpan(text: '1분', style: TextStyle(color: Color(0xFFF97316), fontWeight: FontWeight.w600)),
+              TextSpan(
+                text: '1분',
+                style: TextStyle(
+                  color: Color(0xFFF97316),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
               TextSpan(text: '이면 회원가입 가능해요'),
             ],
           ),
@@ -155,7 +171,10 @@ class _InputName extends StatelessWidget {
             style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
             children: [
               TextSpan(text: '이름 '),
-              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+              TextSpan(
+                text: '*',
+                style: TextStyle(color: Color(0xFFF97316)),
+              ),
             ],
           ),
         ),
@@ -199,7 +218,10 @@ class _InputPassword extends StatelessWidget {
             style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
             children: [
               TextSpan(text: '비밀번호 '),
-              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+              TextSpan(
+                text: '*',
+                style: TextStyle(color: Color(0xFFF97316)),
+              ),
             ],
           ),
         ),
@@ -233,7 +255,10 @@ class _InputPassword extends StatelessWidget {
             style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
             children: [
               TextSpan(text: '비밀번호 확인 '),
-              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+              TextSpan(
+                text: '*',
+                style: TextStyle(color: Color(0xFFF97316)),
+              ),
             ],
           ),
         ),
@@ -249,7 +274,10 @@ class _InputPassword extends StatelessWidget {
             children: const [
               Icon(Icons.error_outline, size: 16, color: Color(0xFFDC2626)),
               SizedBox(width: 6),
-              Text('비밀번호를 다시 확인해주세요', style: TextStyle(fontSize: 12, color: Color(0xFFDC2626))),
+              Text(
+                '비밀번호를 다시 확인해주세요',
+                style: TextStyle(fontSize: 12, color: Color(0xFFDC2626)),
+              ),
             ],
           ),
         ],
@@ -296,7 +324,10 @@ class _InputEmail extends StatelessWidget {
             style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
             children: [
               TextSpan(text: '이메일 주소 '),
-              TextSpan(text: '*', style: TextStyle(color: Color(0xFFF97316))),
+              TextSpan(
+                text: '*',
+                style: TextStyle(color: Color(0xFFF97316)),
+              ),
             ],
           ),
         ),
@@ -317,35 +348,60 @@ class _InputEmail extends StatelessWidget {
             SizedBox(
               height: 40,
               child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFFF97316),
-                  foregroundColor: Colors.white,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                ).copyWith(
-                  backgroundColor: WidgetStateProperty.resolveWith((states) {
-                    if (states.contains(WidgetState.disabled)) {
-                      return const Color(0xFFF97316).withValues(alpha: 0.5);
-                    }
-                    return const Color(0xFFF97316);
-                  }),
-                ),
-                onPressed: (email.isNotEmpty && isSch && !sending) ? onSend : null,
+                style:
+                    ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFF97316),
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ).copyWith(
+                      backgroundColor: WidgetStateProperty.resolveWith((
+                        states,
+                      ) {
+                        if (states.contains(WidgetState.disabled)) {
+                          return const Color(0xFFF97316).withValues(alpha: 0.5);
+                        }
+                        return const Color(0xFFF97316);
+                      }),
+                    ),
+                onPressed: (email.isNotEmpty && isSch && !sending)
+                    ? onSend
+                    : null,
                 child: sending
-                    ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
-                    : const Text('인증 요청', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : const Text(
+                        '인증 요청',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
               ),
             ),
           ],
         ),
         if (emailSent) ...[
           const SizedBox(height: 12),
-          const Text('인증 코드', style: TextStyle(fontSize: 14, color: Color(0xFF374151))),
+          const Text(
+            '인증 코드',
+            style: TextStyle(fontSize: 14, color: Color(0xFF374151)),
+          ),
           const SizedBox(height: 8),
           Row(
             children: [
               Expanded(
                 child: TextField(
-                  decoration: const InputDecoration(border: UnderlineInputBorder()),
+                  decoration: const InputDecoration(
+                    border: UnderlineInputBorder(),
+                  ),
                   onChanged: onChangeCode,
                 ),
               ),
@@ -353,22 +409,42 @@ class _InputEmail extends StatelessWidget {
               SizedBox(
                 height: 40,
                 child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF22C55E),
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                  ).copyWith(
-                    backgroundColor: WidgetStateProperty.resolveWith((states) {
-                      if (states.contains(WidgetState.disabled)) {
-                        return const Color(0xFF22C55E).withValues(alpha: 0.5);
-                      }
-                      return const Color(0xFF22C55E);
-                    }),
-                  ),
+                  style:
+                      ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF22C55E),
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                      ).copyWith(
+                        backgroundColor: WidgetStateProperty.resolveWith((
+                          states,
+                        ) {
+                          if (states.contains(WidgetState.disabled)) {
+                            return const Color(
+                              0xFF22C55E,
+                            ).withValues(alpha: 0.5);
+                          }
+                          return const Color(0xFF22C55E);
+                        }),
+                      ),
                   onPressed: (code.isNotEmpty && !verifying) ? onVerify : null,
                   child: verifying
-                      ? const SizedBox(height: 16, width: 16, child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white))
-                      : const Text('확인', style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                      ? const SizedBox(
+                          height: 16,
+                          width: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: Colors.white,
+                          ),
+                        )
+                      : const Text(
+                          '확인',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
                 ),
               ),
             ],
@@ -378,21 +454,40 @@ class _InputEmail extends StatelessWidget {
             onTap: () => openExternalUrl('https://mail.sch.ac.kr'),
             child: const Text(
               '메일함 열기 (mail.sch.ac.kr)',
-              style: TextStyle(fontSize: 12, color: Color(0xFF2563EB), decoration: TextDecoration.underline),
+              style: TextStyle(
+                fontSize: 12,
+                color: Color(0xFF2563EB),
+                decoration: TextDecoration.underline,
+              ),
             ),
           ),
           if (verified) ...[
             const SizedBox(height: 8),
-            const Text('✅ 인증 완료', style: TextStyle(fontSize: 12, color: Color(0xFF16A34A))),
+            const Text(
+              '✅ 인증 완료',
+              style: TextStyle(fontSize: 12, color: Color(0xFF16A34A)),
+            ),
           ],
         ],
         if (error != null) ...[
           const SizedBox(height: 8),
           Row(
             children: [
-              const Icon(Icons.error_outline, size: 16, color: Color(0xFFDC2626)),
+              const Icon(
+                Icons.error_outline,
+                size: 16,
+                color: Color(0xFFDC2626),
+              ),
               const SizedBox(width: 6),
-              Expanded(child: Text(error!, style: const TextStyle(fontSize: 12, color: Color(0xFFDC2626)))),
+              Expanded(
+                child: Text(
+                  error!,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: Color(0xFFDC2626),
+                  ),
+                ),
+              ),
             ],
           ),
         ],
@@ -431,7 +526,10 @@ class _Agreements extends StatelessWidget {
                 onChanged: (v) => onToggleAll(v ?? false),
               ),
               const SizedBox(width: 6),
-              const Text('모두 동의합니다', style: TextStyle(fontWeight: FontWeight.w600)),
+              const Text(
+                '모두 동의합니다',
+                style: TextStyle(fontWeight: FontWeight.w600),
+              ),
             ],
           ),
         ),
@@ -445,7 +543,9 @@ class _Agreements extends StatelessWidget {
                 label: '[필수] 이용약관 동의',
                 onToggle: onToggleTos,
                 onView: () => Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const SignupTermsScreen(doc: 'tos')),
+                  MaterialPageRoute(
+                    builder: (_) => const SignupTermsScreen(doc: 'tos'),
+                  ),
                 ),
               ),
               const SizedBox(height: 8),
@@ -454,7 +554,9 @@ class _Agreements extends StatelessWidget {
                 label: '[필수] 개인 정보 수집 및 이용 동의',
                 onToggle: onTogglePrivacy,
                 onView: () => Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const SignupTermsScreen(doc: 'privacy')),
+                  MaterialPageRoute(
+                    builder: (_) => const SignupTermsScreen(doc: 'privacy'),
+                  ),
                 ),
               ),
             ],
@@ -471,18 +573,23 @@ class _AgreementRow extends StatelessWidget {
   final ValueChanged<bool> onToggle;
   final VoidCallback onView;
 
-  const _AgreementRow({required this.checked, required this.label, required this.onToggle, required this.onView});
+  const _AgreementRow({
+    required this.checked,
+    required this.label,
+    required this.onToggle,
+    required this.onView,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        AppCheckbox(
-          value: checked,
-          onChanged: (v) => onToggle(v ?? false),
-        ),
+        AppCheckbox(value: checked, onChanged: (v) => onToggle(v ?? false)),
         Expanded(
-          child: Text(label, style: const TextStyle(fontSize: 12, color: Color(0xFF374151))),
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 12, color: Color(0xFF374151)),
+          ),
         ),
         TextButton(
           onPressed: onView,
@@ -501,4 +608,3 @@ class _AgreementRow extends StatelessWidget {
 }
 
 /// 간단 라우터: 아직 main.dart 라우트 연결 전이라 credentials 화면 내부에서만 사용.
-

--- a/lib/features/store/viewmodels/store_list_view_model.dart
+++ b/lib/features/store/viewmodels/store_list_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import '../../../common/dio/api_error_mapper.dart';
 import '../../../common/dio/api_exception.dart';
@@ -6,22 +7,9 @@ import '../models/store_models.dart';
 import '../repositories/store_repository.dart';
 
 class StoreListViewModel extends ChangeNotifier {
-  StoreListViewModel(this._repo);
-
-  final StoreRepository _repo;
-
-  bool loading = false;
-  String? errorMessage;
-  List<StoreListItem> items = [];
-  final Set<int> _favoriteUpdating = {};
-
-  bool isFavoriteUpdating(int storeId) => _favoriteUpdating.contains(storeId);
-
-  Future<void> load() async {
-    if (loading) return;
-    loading = true;
+  /// API 호출 및 즐겨찾기 동기화, 에러 처리까지 담당하는 내부 메서드
+  Future<void> _fetchStoreList({bool isRefresh = false}) async {
     errorMessage = null;
-    notifyListeners();
     try {
       final list = await _repo.getStoreList();
       try {
@@ -37,12 +25,45 @@ class StoreListViewModel extends ChangeNotifier {
       if (e is ApiException) {
         errorMessage = mapErrorToMessage(e, responseData: e.details);
       } else {
-        errorMessage = '매장 목록을 불러오지 못했습니다.';
+        errorMessage = isRefresh
+            ? '매장 목록을 새로고침하지 못했습니다.'
+            : '매장 목록을 불러오지 못했습니다.';
       }
-    } finally {
-      loading = false;
-      notifyListeners();
     }
+    notifyListeners();
+  }
+
+  StoreListViewModel(this._repo);
+
+  final StoreRepository _repo;
+
+  bool loading = false;
+  String? errorMessage;
+  List<StoreListItem> items = [];
+  final Set<int> _favoriteUpdating = {};
+
+  bool isFavoriteUpdating(int storeId) => _favoriteUpdating.contains(storeId);
+
+  Future<void> load() async {
+    if (loading) return;
+    loading = true;
+    notifyListeners();
+    await _fetchStoreList();
+    loading = false;
+    notifyListeners();
+  }
+
+  DateTime? _lastRefreshTime; // 중복 새로고침 방지 (30초 이내 새로고침 시도 무시)
+
+  Future<void> refresh() async {
+    final now = DateTime.now();
+    if (_lastRefreshTime != null &&
+        now.difference(_lastRefreshTime!) < const Duration(seconds: 30)) {
+      if (kDebugMode) debugPrint("최근 새로고침 시도");
+      return;
+    }
+    _lastRefreshTime = now;
+    await _fetchStoreList(isRefresh: true);
   }
 
   Future<void> toggleFavorite(StoreListItem store) async {

--- a/lib/widgets/HomePage.dart
+++ b/lib/widgets/HomePage.dart
@@ -9,9 +9,9 @@ import 'dart:async';
 import '../features/auth/models/role.dart';
 import '../features/mypage/screens/notification_settings_screen.dart';
 import '../features/auth/repositories/auth_repository.dart';
+import '../features/store/viewmodels/store_list_view_model.dart';
 import '../features/notice/viewmodels/notice_list_view_model.dart';
 import '../features/notice/widgets/notice_list_section.dart';
-import '../features/store/viewmodels/store_list_view_model.dart';
 import 'TabBar.dart';
 
 class HomePage extends StatefulWidget {
@@ -73,9 +73,13 @@ class _HomePageState extends State<HomePage> {
         centerTitle: false,
         actions: [
           IconButton(
-            icon: const Icon(Icons.notifications_outlined, color: Color(0xFF111827)),
-            onPressed: () => Navigator.of(context)
-                .pushNamed(NotificationSettingsScreen.routeName),
+            icon: const Icon(
+              Icons.notifications_outlined,
+              color: Color(0xFF111827),
+            ),
+            onPressed: () => Navigator.of(
+              context,
+            ).pushNamed(NotificationSettingsScreen.routeName),
           ),
         ],
       ),
@@ -114,19 +118,30 @@ class _HomePageState extends State<HomePage> {
                                 ? null
                                 : () {
                                     if (_selectedTab == HomeTabType.notice) {
-                                      context.read<NoticeListViewModel>().refresh();
+                                      context
+                                          .read<NoticeListViewModel>()
+                                          .refresh();
+                                      if (kDebugMode) debugPrint("공지사항 새로고침");
                                       return;
                                     }
-                                    context.read<StoreListViewModel>().load();
+                                    context
+                                        .read<StoreListViewModel>()
+                                        .refresh();
+                                    if (kDebugMode) debugPrint("오늘의 천밥 새로고침");
                                   },
                             icon: isRefreshing
                                 ? const SizedBox(
                                     width: 20,
                                     height: 20,
-                                    child: CircularProgressIndicator(strokeWidth: 2, color: Color(0xFF54AAFF)),
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: Color(0xFF54AAFF),
+                                    ),
                                   )
                                 : const Icon(Icons.refresh, color: Colors.grey),
-                            highlightColor: Colors.orange.withValues(alpha: 0.2),
+                            highlightColor: Colors.orange.withValues(
+                              alpha: 0.2,
+                            ),
                             padding: EdgeInsets.zero,
                             constraints: const BoxConstraints(),
                           ),


### PR DESCRIPTION
## PR 요약
QA 기반 버그 수정: 네비게이션 스택 정리, 자주 쓰는 메뉴 상태 관리 개선, 홈 새로고침 로직 분리

## 관련 이슈
- closes #26

## 변경 내용

### 네비게이션 스택 정리 (로그인/회원가입)
| 파일 | 변경 | 설명 |
|------|------|------|
| `login_screen.dart` | 수정 | 자동 로그인·수동 로그인 시 `pushReplacementNamed` → `pushNamedAndRemoveUntil`로 변경, 이전 스택 전체 제거 |
| `signup_credentials_screen.dart` | 수정 | 회원가입 완료 시 `pushReplacementNamed` → `pushNamedAndRemoveUntil`로 변경, 회원가입 관련 스택 전체 제거 후 `/login` 이동 |

### 자주 쓰는 메뉴 상태 관리 개선 (관리자)
| 파일 | 변경 | 설명 |
|------|------|------|
| `admin_frequent_menu_edit_view_model.dart` | 수정 | `_initialMenus` 저장 + `_updateDirty()` 도입으로 실제 변경 여부 추적, 저장/삭제 후 초기값 동기화 |
| `admin_menu_edit_view_model.dart` | 수정 | 동일하게 `_initialMenus` + `_updateDirty()` 패턴 적용 |
| `admin_frequent_menu_edit_screen.dart` | 수정 | 뒤로가기 시 dirty 상태 기반 `AppConfirmDialog.showDiscard()` 연동, 전체 삭제 후 저장 시 빈 리스트 전송 에러 수정 |

### 홈 새로고침 로직 개선
| 파일 | 변경 | 설명 |
|------|------|------|
| `store_list_view_model.dart` | 수정 | `_fetchStoreList()` 추출, `load()`/`refresh()` 분리, 30초 쿨다운 로직 적용 |
| `HomePage.dart` | 수정 | 새로고침 시 `refresh()` 호출, 로딩 중 스피너 표시 + 버튼 비활성화 |

## 커밋 목록
- `fef0cf8` refactor: StoreListViewModel 로직 분리 및 HomePage 새로고침 개선
- `5c21842` fix(admin): 자주 쓰는 메뉴 삭제/저장 후 "변경사항이 있어요" 모달 오작동 수정
- `2b0a98d` fix: 자주 쓰는 메뉴 전체 삭제 후 저장 시 서버 에러 수정
- `db68717` fix: 회원가입 완료 후 네비게이션 스택 정리

## 체크리스트
- [x] 회원가입 → 로그인 → 마이페이지 → 뒤로가기 시 회원가입 화면 노출 안됨
- [x] 로그인 성공 시 네비게이션 스택 완전 초기화 (`pushNamedAndRemoveUntil`)
- [x] 자동 로그인 시에도 동일하게 스택 초기화 적용
- [x] 자주 쓰는 메뉴 삭제 후 뒤로가기 시 "변경사항이 있어요" 오작동 수정
- [x] 자주 쓰는 메뉴 전체 삭제 후 저장 정상 동작
- [x] 홈 화면 새로고침 30초 쿨다운 정상 동작
- [x] refactor/27 리베이스 충돌 해결 (공통 컴포넌트 `AppConfirmDialog`, `AppBarCommon`, `AppButton` 반영)